### PR TITLE
Closes #16

### DIFF
--- a/SwiftTweaks/Clip.swift
+++ b/SwiftTweaks/Clip.swift
@@ -21,16 +21,3 @@ internal func clip<U: SignedNumberType>(value: U, _ minimum: U?, _ maximum: U?) 
 
 	return result
 }
-
-extension Tweak where T: SignedNumberType {
-	internal func clipIfSignedNumberType(value: T) -> T {
-		return clip(value, minimumValue, maximumValue)
-	}
-}
-
-extension Tweak {
-	internal func clipIfSignedNumberType(value: T) -> T {
-		/// Since we're not a SignedNumberType, this just returns the value.
-		return value
-	}
-}

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -28,28 +28,31 @@ internal class TweakPersistency {
 		self.tweakCache = self.diskPersistency.loadFromDisk()
 	}
 
-	func currentValueForTweak<T>(tweak: Tweak<T>) -> T? {
+	internal func currentValueForTweak<T>(tweak: Tweak<T>) -> T? {
+		return persistedValueForTweakIdentifiable(AnyTweak(tweak: tweak)) as? T
+	}
 
-		if let currentValue = currentValueForTweakIdentifiable(AnyTweak(tweak: tweak)) as? T {
+	internal func currentValueForTweak<T where T: SignedNumberType>(tweak: Tweak<T>) -> T? {
+		if let currentValue = persistedValueForTweakIdentifiable(AnyTweak(tweak: tweak)) as? T {
 				// If the tweak can be clipped, then we'll need to clip it - because
-				// the tweak might've been persisted without a min / max, but we've since added those values.
+				// the tweak might've been persisted without a min / max, but then you changed the tweak definition.
 				// example: you tweaked it to 11, then set a max of 10 - the persisted value is still 11!
-				return tweak.clipIfSignedNumberType(currentValue)
+				return clip(currentValue, tweak.minimumValue, tweak.maximumValue)
 		}
 
 		return nil
 	}
 
-	func currentValueForTweakIdentifiable(tweakID: TweakIdentifiable) -> TweakableType? {
+	internal func persistedValueForTweakIdentifiable(tweakID: TweakIdentifiable) -> TweakableType? {
 		return tweakCache[tweakID.persistenceIdentifier]
 	}
 
-	func setValue(value: TweakableType?,  forTweakIdentifiable tweakID: TweakIdentifiable) {
+	internal func setValue(value: TweakableType?,  forTweakIdentifiable tweakID: TweakIdentifiable) {
 		tweakCache[tweakID.persistenceIdentifier] = value
 		self.diskPersistency.saveToDisk(tweakCache)
 	}
 
-	func clearAllData() {
+	internal func clearAllData() {
 		tweakCache = [:]
 		self.diskPersistency.saveToDisk(tweakCache)
 	}

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -118,7 +118,7 @@ public final class TweakStore {
 	}
 
 	internal func currentViewDataForTweak(tweak: AnyTweak) -> TweakViewData {
-		let cachedValue = persistence.currentValueForTweakIdentifiable(tweak)
+		let cachedValue = persistence.persistedValueForTweakIdentifiable(tweak)
 
 		switch tweak.tweakDefaultData {
 		case let .Boolean(defaultValue: defaultValue):


### PR DESCRIPTION
Includes a neat little workaround for only clipping Tweak<T> when T:
SignedNumberType
