### PR TITLE
Improve default stepSize value for UISteppers

### DIFF
--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		930ECDB81DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930ECDB71DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift */; };
 		931472491BFFB0C800F66D20 /* UIColor+TweaksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931472481BFFB0C800F66D20 /* UIColor+TweaksTests.swift */; };
 		9314724C1BFFB41700F66D20 /* TweakWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A3AF311BF1677B00CAD43B /* TweakWindow.swift */; };
 		9314724D1BFFB41700F66D20 /* TweaksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AA34561BEBC654004B734B /* TweaksViewController.swift */; };
@@ -113,6 +114,7 @@
 		5752FECD1C05392300AEECD1 /* iOS-Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "iOS-Base.xcconfig"; sourceTree = "<group>"; };
 		5752FECE1C05392300AEECD1 /* iOS-Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "iOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		5752FECF1C05392300AEECD1 /* iOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "iOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
+		930ECDB71DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TweakViewData+TweaksTests.swift"; sourceTree = "<group>"; };
 		931472481BFFB0C800F66D20 /* UIColor+TweaksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+TweaksTests.swift"; sourceTree = "<group>"; };
 		931A24711BFA77FB00E40192 /* TweakColorEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakColorEditViewController.swift; sourceTree = "<group>"; };
 		931A24731BFA7A3800E40192 /* TweakColorCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakColorCell.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 				939F2CCB1CB715E800345E03 /* Clipping+TweaksTest.swift */,
 				93478C7B1CBDF03A0064D8AD /* Precision+TweaksTests.swift */,
 				939F2CD11CB71AC900345E03 /* Tweak+TweaksTests.swift */,
+				930ECDB71DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift */,
 				93A84EE21BEAE86E0022D2F3 /* Info.plist */,
 			);
 			path = SwiftTweaksTests;
@@ -566,6 +569,7 @@
 				93B058E51CC53AD100AB2759 /* Precision.swift in Sources */,
 				931472521BFFB41700F66D20 /* ColorRepresentation.swift in Sources */,
 				93A84EE11BEAE86E0022D2F3 /* SwiftTweaksTests.swift in Sources */,
+				930ECDB81DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift in Sources */,
 				93B058D71CBDF58500AB2759 /* TweakClusterType.swift in Sources */,
 				939F2CCF1CB7197800345E03 /* HitTransparentWindow.swift in Sources */,
 				931472511BFFB41700F66D20 /* TweakColorEditViewController.swift in Sources */,

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -204,44 +204,26 @@ internal final class TweakTableCell: UITableViewCell {
 			switchControl.on = value
 			textFieldEnabled = false
 
-		case let .Integer(value: value, _, _, _, stepSize: step):
-			self.updateStepper(
-				value: Double(value),
-				stepperLimits: viewData.stepperLimits!,
-				stepSize: Double(step ?? 1)
-			)
-
-			textField.text = String(value)
-			textField.keyboardType = .NumberPad
-			textFieldEnabled = true
-
-		case let .Float(value: value, _, _, _, stepSize: step):
-			self.updateStepper(
-				value: Double(value),
-				stepperLimits: viewData.stepperLimits!,
-				stepSize: Double(step ?? (stepperControl.maximumValue - stepperControl.minimumValue)/100)
-			)
-
-			textField.text = value.stringValueRoundedToNearest(.Thousandth)
-			textField.keyboardType = .DecimalPad
-			textFieldEnabled = true
-
-		case let .DoubleTweak(value: value, _, _, _, stepSize: step):
-			self.updateStepper(
-				value: value,
-				stepperLimits: viewData.stepperLimits!,
-				stepSize: step ?? (stepperControl.maximumValue - stepperControl.minimumValue)/100
-			)
-
-			textField.text = value.stringValueRoundedToNearest(.Thousandth)
-			textField.keyboardType = .DecimalPad
-			textFieldEnabled = true
-
 		case let .Color(value: value, _):
 			colorChit.backgroundColor = value
 			textField.text = value.hexString
 			textFieldEnabled = false
 
+		case .Integer:
+			let doubleValue = viewData.doubleValue!
+			self.updateStepper(value: doubleValue, stepperValues: viewData.stepperValues!)
+
+			textField.text = String(doubleValue)
+			textField.keyboardType = .NumberPad
+			textFieldEnabled = true
+
+		case .Float, .DoubleTweak:
+			let doubleValue = viewData.doubleValue!
+			self.updateStepper(value: doubleValue, stepperValues: viewData.stepperValues!)
+
+			textField.text = viewData.doubleValue!.stringValueRoundedToNearest(.Thousandth)
+			textField.keyboardType = .DecimalPad
+			textFieldEnabled = true
 		}
 
 		textFieldEnabled = textFieldEnabled && !self.isInFloatingTweakGroupWindow
@@ -251,10 +233,11 @@ internal final class TweakTableCell: UITableViewCell {
 
 	}
 
-	private func updateStepper(value value: Double, stepperLimits: (stepperMin: Double, stepperMax: Double), stepSize: Double) {
-		(stepperControl.minimumValue, stepperControl.maximumValue) = stepperLimits
+	private func updateStepper(value value: Double, stepperValues: TweakViewData.StepperValues) {
+		stepperControl.minimumValue = stepperValues.stepperMin
+		stepperControl.maximumValue = stepperValues.stepperMax
+		stepperControl.stepValue = stepperValues.stepSize
 		stepperControl.value = value
-		stepperControl.stepValue = stepSize
 	}
 
 

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -49,6 +49,20 @@ internal enum TweakViewData {
 		}
 	}
 
+	/// For signedNumberType tweaks, this is a shortcut to `value` as a Double
+	var doubleValue: Double? {
+		switch self {
+		case .Boolean, .Color:
+			return nil
+		case let .Integer(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .Float(value: floatValue, _, _, _, _):
+			return Double(floatValue)
+		case let .DoubleTweak(value: doubleValue, _, _, _, _):
+			return doubleValue
+		}
+	}
+
 	var stringRepresentation: (String, Bool) {
 		let string: String
 		let differsFromDefault: Bool
@@ -83,70 +97,113 @@ internal enum TweakViewData {
 
 	// These are the defaults that UIKit has for the UIStepper min and max
 	internal static let stepperDefaultMinimum: Double = 0
-	internal static let stepperDefaultMaximum: Double = 100
+
+	internal static let stepperDefaultStepSizeLarge: Double = 1
+	internal static let stepperDefaultMaximumLarge: Double = 100
+
+	internal static let stepperDefaultStepSizeSmall: Double = 0.01
+	internal static let stepperDefaultMaximumSmall: Double = 1
 
 	/// Used when no max is given and the default is > stepperDefaultMaximum
 	internal static let stepperBoundsMultiplier: Double = 2
 
+	/// Represents the configuration for a UIStepper's min/max/stepSize values
+	internal typealias StepperValues = (stepperMin: Double, stepperMax: Double, stepSize: Double)
+
 	/// UISteppers *require* a maximum value (ugh) and they default to 100 (ughhhh)
-	/// ...so let's set something sensible.
-	var stepperLimits: (stepperMin: Double, stepperMax: Double)? {
+	/// Since UIKit requires that we provide max/min/stepSize stuff, let's try to choose reasonable values.
+	/// This procedure:
+	///  - Uses (min = 0, max = 10, stepSize = 0.01) for non-integer tweaks where the default value is smaller than 1 and max is <= 1 if it exists.
+	///  - Defaults to (min = 0, max = 100, and stepSize = 1) for other tweaks
+	///  - Adjusts the (min = 0, max = 100) bit for tweaks that are (< 0) or (> 100)
+	///
+	/// Of course, the actual min/max are enforced by the Tweak's definition,
+	/// so the user can create/enforce their own min/max by typing in the value into the UI
+	/// or by adjusting the Tweak definition to include exact min/max/step preferences.
+	var stepperValues: StepperValues? {
 		precondition(self.isSignedNumberType)
 
 		let currentValue: Double
 		let defaultValue: Double
 		let minimum: Double?
 		let maximum: Double?
-
+		let step: Double?
+		let isInteger: Bool
 		switch self {
 		case .Boolean, .Color:
 			return nil
 
-		case let .Integer(intValue, intDefaultValue, intMin, intMax, _):
+		case let .Integer(intValue, intDefaultValue, intMin, intMax, intStep):
 			currentValue = Double(intValue)
 			defaultValue = Double(intDefaultValue)
 			minimum = intMin.map(Double.init)
 			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
 
-		case let .Float(floatValue, floatDefaultValue, floatMin, floatMax, _):
+		case let .Float(floatValue, floatDefaultValue, floatMin, floatMax, floatStep):
 			currentValue = Double(floatValue)
 			defaultValue = Double(floatDefaultValue)
 			minimum = floatMin.map(Double.init)
 			maximum = floatMax.map(Double.init)
+			step = floatStep.map(Double.init)
+			isInteger = false
 
-		case let .DoubleTweak(doubleValue, doubleDefaultValue, doubleMin, doubleMax, _):
+		case let .DoubleTweak(doubleValue, doubleDefaultValue, doubleMin, doubleMax, doubleStep):
 			currentValue = doubleValue
 			defaultValue = doubleDefaultValue
 			minimum = doubleMin
 			maximum = doubleMax
-
+			step = doubleStep
+			isInteger = false
 		}
 
-		// UIStepper defaults to 0 and 100, so we'll use those as a fallback.
+		// UIStepper defaults to (min = 0, max = 100, step = 1), so we'll use those as a fallback.
 		var resultMin: Double = TweakViewData.stepperDefaultMinimum
-		var resultMax: Double = TweakViewData.stepperDefaultMaximum
+		var resultMax: Double = TweakViewData.stepperDefaultMaximumLarge
+		var resultStep: Double = TweakViewData.stepperDefaultStepSizeLarge
 
-		// If we have a currentValue or defaultValue that's outside the bounds, we'll want to give some space to 'em.
-		if (defaultValue < resultMin) || (currentValue < resultMin) {
-			let lowerValue = min(currentValue, defaultValue)
-			resultMin = (lowerValue < 0) ?
-				lowerValue * TweakViewData.stepperBoundsMultiplier :
-				lowerValue / TweakViewData.stepperBoundsMultiplier
+		// We'll use the "small defaults" when all of these conditions are met:
+		//  - non-integer
+		//  - defaultValue 0 < x < 1
+		//  - currentValue 0 < x < 1
+		//  - maxValue (if given) <= 1
+		let isSmallDefaultValue = (0 <= defaultValue) && (defaultValue < TweakViewData.stepperDefaultMaximumSmall)
+		let isSmallCurrentValue = (0 <= currentValue) && (currentValue < TweakViewData.stepperDefaultMaximumSmall)
+		let isSmallMaxValue = (maximum ?? 0) <= TweakViewData.stepperDefaultMaximumSmall
+		if !isInteger && isSmallDefaultValue && isSmallMaxValue && isSmallCurrentValue {
+			resultMax = TweakViewData.stepperDefaultMaximumSmall
+			resultStep = TweakViewData.stepperDefaultStepSizeSmall
+
+		} else {
+			// If we have a currentValue or defaultValue that's outside the bounds, we'll want to give some space to 'em.
+			if (defaultValue < resultMin) || (currentValue < resultMin) {
+				let lowerValue = min(currentValue, defaultValue)
+				resultMin = (lowerValue < 0) ?
+					lowerValue * TweakViewData.stepperBoundsMultiplier :
+					lowerValue / TweakViewData.stepperBoundsMultiplier
+			}
+
+			if (defaultValue > resultMax) || (currentValue > resultMax) {
+				let upperValue = max(currentValue, defaultValue)
+				resultMax = (upperValue < 0) ?
+					upperValue / TweakViewData.stepperBoundsMultiplier :
+					upperValue * TweakViewData.stepperBoundsMultiplier
+			}
 		}
 
-		if (defaultValue > resultMax) || (currentValue > resultMax) {
-			let upperValue = max(currentValue, defaultValue)
-			resultMax = (upperValue < 0) ?
-				upperValue / TweakViewData.stepperBoundsMultiplier :
-				upperValue * TweakViewData.stepperBoundsMultiplier
+		// If the tweak is an integer, whatever we've got, let's round it to the nearest integer.
+		if isInteger {
+			resultMin = resultMin.roundToNearest(.Integer)
+			resultMax = resultMax.roundToNearest(.Integer)
+			resultStep = resultStep.roundToNearest(.Integer)
 		}
 
-		// Lastly, to override any above work: if an explicit minimum or maximum were given,
-		// we'd want to use that instead.
+		// Lastly, to override any above work: if an explicit min/max/step were given, use those.
 		resultMin = minimum ?? resultMin
 		resultMax = maximum ?? resultMax
+		resultStep = step ?? resultStep
 
-		return (resultMin, resultMax)
+		return (resultMin, resultMax, resultStep)
 	}
-
 }

--- a/SwiftTweaksTests/Clipping+TweaksTest.swift
+++ b/SwiftTweaksTests/Clipping+TweaksTest.swift
@@ -29,7 +29,7 @@ private struct ClippingTestCase<T where T: SignedNumberType> {
 	}
 }
 
-private struct StepperTestCase {
+private struct StepperClippingTestCase {
 	let currentValue: Double
 	let defaultValue: Double
 	let min: Double?
@@ -44,7 +44,7 @@ private struct StepperTestCase {
 		self.expected = expected
 	}
 
-	static func confirmTest(testCase: StepperTestCase) {
+	static func confirmTest(testCase: StepperClippingTestCase) {
 		let tweakViewData = TweakViewData.DoubleTweak(
 			value: testCase.currentValue,
 			defaultValue: testCase.defaultValue,
@@ -53,7 +53,7 @@ private struct StepperTestCase {
 			stepSize: nil
 		)
 
-		let (derivedMin, derivedMax) = tweakViewData.stepperLimits!
+		let (derivedMin, derivedMax, _) = tweakViewData.stepperValues!
 		let (expectedMin, expectedMax) = testCase.expected
 		XCTAssertEqual(derivedMin, expectedMin, "Derived minimum didn't match expected.")
 		XCTAssertEqual(derivedMax, expectedMax, "Derived maximum didn't match expected.")
@@ -83,24 +83,24 @@ class Clipping_TweaksTests: XCTestCase {
 
 	func testStepperLimits() {
 		let defaultMin = TweakViewData.stepperDefaultMinimum
-		let defaultMax = TweakViewData.stepperDefaultMaximum
+		let defaultMax = TweakViewData.stepperDefaultMaximumLarge
 		let defaultBounds = (defaultMin, defaultMax)
 		let boundsMultiplier = TweakViewData.stepperBoundsMultiplier
 		[
-			StepperTestCase(current: 10, def: 10, min: nil, max: nil, expected: defaultBounds),
+			StepperClippingTestCase(current: 10, def: 10, min: nil, max: nil, expected: defaultBounds),
 
-			StepperTestCase(current: 10, def: 40, min: nil, max: nil, expected: defaultBounds),
-			StepperTestCase(current: 40, def: 10, min: nil, max: nil, expected: defaultBounds),
+			StepperClippingTestCase(current: 10, def: 40, min: nil, max: nil, expected: defaultBounds),
+			StepperClippingTestCase(current: 40, def: 10, min: nil, max: nil, expected: defaultBounds),
 
-			StepperTestCase(current: 50, def: 101, min: nil, max: nil, expected: (defaultMin, 101 * boundsMultiplier)),
-			StepperTestCase(current: -10, def: -1, min: nil, max: nil, expected: (-10 * boundsMultiplier, defaultMax)),
-			StepperTestCase(current: 165, def: 165, min: nil, max: nil, expected: (defaultMin, 165 * boundsMultiplier)),
-			StepperTestCase(current: 60, def: -20, min: nil, max: nil, expected: (-20 * boundsMultiplier, defaultMax)),
+			StepperClippingTestCase(current: 50, def: 101, min: nil, max: nil, expected: (defaultMin, 101 * boundsMultiplier)),
+			StepperClippingTestCase(current: -10, def: -1, min: nil, max: nil, expected: (-10 * boundsMultiplier, defaultMax)),
+			StepperClippingTestCase(current: 165, def: 165, min: nil, max: nil, expected: (defaultMin, 165 * boundsMultiplier)),
+			StepperClippingTestCase(current: 60, def: -20, min: nil, max: nil, expected: (-20 * boundsMultiplier, defaultMax)),
 
-			StepperTestCase(current: -30, def: -40, min: -100, max: 0, expected: (-100, 0)),
-			StepperTestCase(current: 600, def: 500, min: 400, max: 1000, expected: (400, 1000)),
+			StepperClippingTestCase(current: -30, def: -40, min: -100, max: 0, expected: (-100, 0)),
+			StepperClippingTestCase(current: 600, def: 500, min: 400, max: 1000, expected: (400, 1000)),
 
-			StepperTestCase(current: 400, def: 200, min: nil, max: nil, expected: (defaultMin, 400 * boundsMultiplier)),
-		].forEach(StepperTestCase.confirmTest)
+			StepperClippingTestCase(current: 400, def: 200, min: nil, max: nil, expected: (defaultMin, 400 * boundsMultiplier)),
+		].forEach(StepperClippingTestCase.confirmTest)
 	}
 }

--- a/SwiftTweaksTests/TweakViewData+TweaksTests.swift
+++ b/SwiftTweaksTests/TweakViewData+TweaksTests.swift
@@ -1,0 +1,209 @@
+//
+//  TweakViewData+TweaksTests.swift
+//  SwiftTweaks
+//
+//  Created by Bryan Clark on 10/6/16.
+//  Copyright © 2016 Khan Academy. All rights reserved.
+//
+
+import XCTest
+
+class TweakViewData_TweaksTests: XCTestCase {
+
+	private struct StepperTestCase {
+		let defaultValue: Double
+		let currentValue: Double
+		let customMin: Double?
+		let customMax: Double?
+		let customStep: Double?
+		let expectedStep: Double?
+		let expectedBounds: (Double, Double)?
+
+		var intTweakViewData: TweakViewData {
+			return .Integer(
+				value: Int(currentValue),
+				defaultValue: Int(defaultValue),
+				min: customMin.map(Int.init),
+				max: customMax.map(Int.init),
+				stepSize: customStep.map(Int.init)
+			)
+		}
+
+		var floatTweakViewData: TweakViewData {
+			return .Float(
+				value: CGFloat(currentValue),
+				defaultValue: CGFloat(defaultValue),
+				min: customMin.map {CGFloat.init($0) },
+				max: customMax.map {CGFloat.init($0) },
+				stepSize: customStep.map {CGFloat.init($0) }
+			)
+		}
+
+		var doubleTweakViewData: TweakViewData {
+			return .DoubleTweak(
+				value: currentValue,
+				defaultValue: defaultValue,
+				min: customMin,
+				max: customMax,
+				stepSize: customStep
+			)
+		}
+
+		static func verifyNonIntegerStepSizeForTestCase(testCase: StepperTestCase) {
+			let floatStepSize = testCase.floatTweakViewData.stepperValues!.stepSize
+			XCTAssertEqualWithAccuracy(
+				floatStepSize,
+				testCase.expectedStep!,
+				accuracy: Double(FLT_EPSILON)
+			)
+
+			let doubleStepSize = testCase.doubleTweakViewData.stepperValues!.stepSize
+			XCTAssertEqualWithAccuracy(
+				doubleStepSize,
+				testCase.expectedStep!,
+				accuracy: DBL_EPSILON
+			)
+		}
+
+		static func verifyIntegerStepSizeForTestCase(testCase: StepperTestCase) {
+			let intStepSize = testCase.intTweakViewData.stepperValues!.stepSize
+			XCTAssertEqual(Int(intStepSize), Int(testCase.expectedStep!))
+		}
+
+		static func verifyStepperBoundsTestCase(testCase: StepperTestCase) {
+			XCTAssertEqualWithAccuracy(
+				testCase.expectedBounds!.0,
+				testCase.floatTweakViewData.stepperValues!.stepperMin,
+				accuracy: Double(FLT_EPSILON)
+			)
+
+			XCTAssertEqualWithAccuracy(
+				testCase.expectedBounds!.1,
+				testCase.floatTweakViewData.stepperValues!.stepperMax,
+				accuracy: Double(FLT_EPSILON)
+			)
+
+			XCTAssertEqualWithAccuracy(
+				testCase.expectedBounds!.0,
+				testCase.doubleTweakViewData.stepperValues!.stepperMin,
+				accuracy: DBL_EPSILON
+			)
+
+			XCTAssertEqualWithAccuracy(
+				testCase.expectedBounds!.1,
+				testCase.doubleTweakViewData.stepperValues!.stepperMax,
+				accuracy: DBL_EPSILON
+			)
+		}
+	}
+
+	func testNonIntegerStepSize() {
+		let tests: [(defaultValue: Double, customMin: Double?, customMax: Double?, customStep: Double?, expectedStep: Double)] = [
+			(0,		nil, nil, nil,		0.01),
+			(0.5,	nil, nil, nil,		0.01),
+			(0.01,  nil, nil, nil,		0.01),
+			(100,	nil, nil, nil,		1),
+			(10,	nil, nil, nil,		1),
+			(2,		nil, nil, nil,		1),
+			(1.01,	nil, nil, nil,		1),
+
+			(0,		0, 100, nil,			1),
+			(0,		0, 10, nil,			1),
+			(0,	    0, 0.1, nil,			0.01),
+			(10,	0, 10, nil,			1),
+
+
+			(0.5,	nil, nil, 0.5,		0.5),
+			(1.0,	nil, nil, 0.1,		0.1),
+			(10,	10, 20, 5,			5),
+		]
+
+		tests
+			.map { return StepperTestCase(
+				defaultValue: $0,
+				currentValue: $0, // NOTE: We don't currently care about currentValue for stepSize calculations.
+				customMin: $1,
+				customMax: $2,
+				customStep: $3,
+				expectedStep: $4,
+				expectedBounds: nil)
+			}
+			.forEach(StepperTestCase.verifyNonIntegerStepSizeForTestCase)
+	}
+
+	func testIntegerStepSize() {
+		let tests: [(defaultValue: Int, customMin: Int?, customMax: Int?, customStep: Int?, expectedStep: Int)] = [
+			(0,		nil, nil, nil,		1),
+			(1,		nil, nil, nil,		1),
+			(2,		nil, nil, nil,		1),
+			(100,	nil, nil, nil,		1),
+			(10,	nil, nil, nil,		1),
+
+
+			(0,		0, 100, nil,			1),
+			(0,		0, 10, nil,			1),
+			(10,	0, 10, nil,			1),
+
+			(1,		nil, nil, 1,			1),
+			(1,		nil, nil, 4,			4),
+			(10,	10, 20, 5,			5),
+			]
+
+		tests
+			.map { return StepperTestCase(
+				defaultValue: Double($0),
+				currentValue: Double($0), // NOTE: We don't currently care about currentValue for stepSize calculations.
+				customMin: $1.map(Double.init),
+				customMax: $2.map(Double.init),
+				customStep: $3.map(Double.init),
+				expectedStep: Double($4),
+				expectedBounds: nil)
+			}
+			.forEach(StepperTestCase.verifyIntegerStepSizeForTestCase)
+	}
+
+	func testStepperLimits() {
+		let defaultMin = TweakViewData.stepperDefaultMinimum
+
+		let defaultMaxLarge = TweakViewData.stepperDefaultMaximumLarge
+		let defaultBoundsLarge = (defaultMin, defaultMaxLarge)
+
+		let defaultMaxSmall = TweakViewData.stepperDefaultMaximumSmall
+		let defaultBoundsSmall = (defaultMin, defaultMaxSmall)
+
+		let boundsMultipler = TweakViewData.stepperBoundsMultiplier
+
+		let tests : [(current: Double, def: Double, min: Double?, max: Double?, expected: (Double, Double))] = [
+			(10, 10, nil, nil, defaultBoundsLarge),
+			(10, 40, nil, nil, defaultBoundsLarge),
+			(40, 10, nil, nil, defaultBoundsLarge),
+
+			(0, 0, nil, nil, defaultBoundsSmall),
+			(0.2, 0.3, nil, nil, defaultBoundsSmall),
+			(0, 0.05, nil, nil, defaultBoundsSmall),
+
+			(50, 101, nil, nil, (defaultMin, 101 * boundsMultipler)),
+			(-10, -1, nil, nil, (-10 * boundsMultipler, defaultMaxLarge)),
+			(165, 165, nil, nil, (defaultMin, 165 * boundsMultipler)),
+			(60, -20, nil, nil, (-20 * boundsMultipler, defaultMaxLarge)),
+
+			(-30, -40, -100, 0, (-100, 0)),
+			(600, 500, 400, 1000, (400, 1000)),
+			(400, 200, nil, nil, (defaultMin, 400 * boundsMultipler)),
+		]
+
+		tests
+			.map { test in
+				return StepperTestCase(
+				defaultValue: test.def,
+				currentValue: test.current,
+				customMin: test.min,
+				customMax: test.max,
+				customStep: nil,
+				expectedStep: nil,
+				expectedBounds: test.expected
+				)
+			}
+			.forEach(StepperTestCase.verifyStepperBoundsTestCase)
+	}
+}


### PR DESCRIPTION
For Int/Float/Double tweaks, the default stepSize values weren't particularly useful. Now, they're much better!

This procedure:
- Uses (min = 0, max = 10, stepSize = 0.01) for non-integer tweaks where the default value is smaller than 1 and max is <= 1 if it exists.
- Defaults to (min = 0, max = 100, and stepSize = 1) for other tweaks
- Adjusts the (min = 0, max = 100) bit for tweaks that are (< 0) or (> 100)

Of course, if the developer provides a custom stepSize, then that's used!