### PR TITLE
Introduce unbind methods based binding identifiers

### DIFF
--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -89,6 +89,11 @@
 		93E777041BED4BBD003F0DE2 /* TweakLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */; };
 		B0E03A551CFF818900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		B0E03A571CFF86E900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
+		D5CE0BDC1DC7DFC200F79235 /* TweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */; };
+		D5CE0BDE1DC7E04A00F79235 /* MultiTweakBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */; };
+		D5CE0BE01DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDF1DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift */; };
+		D5CE0BE11DC7E1FB00F79235 /* TweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */; };
+		D5CE0BE21DC7E1FB00F79235 /* MultiTweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDF1DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -168,6 +173,9 @@
 		93DB80341BFCE4E80031D61A /* AnyTweak.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyTweak.swift; sourceTree = "<group>"; };
 		93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakLibrary.swift; sourceTree = "<group>"; };
 		B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakDebug.swift; sourceTree = "<group>"; };
+		D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakBindingIdentifier.swift; sourceTree = "<group>"; };
+		D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTweakBinding.swift; sourceTree = "<group>"; };
+		D5CE0BDF1DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTweakBindingIdentifier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -281,6 +289,7 @@
 			isa = PBXGroup;
 			children = (
 				93C942581BFBDC550054811A /* TweakBinding.swift */,
+				D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */,
 				937962921BFE7B0A0046E4CE /* TweakViewData.swift */,
 				931A247F1BFA95B000E40192 /* TweakPersistency.swift */,
 				9345EC0D1BF2B9100086AB5D /* TweakCollection.swift */,
@@ -378,6 +387,8 @@
 				93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */,
 				93AA344E1BEBBD2D004B734B /* TweakStore.swift */,
 				B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */,
+				D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */,
+				D5CE0BDF1DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift */,
 				9345EC0C1BF2B9040086AB5D /* Internal */,
 			);
 			name = Model;
@@ -530,6 +541,7 @@
 				93DB80351BFCE4E80031D61A /* AnyTweak.swift in Sources */,
 				933223591CB842D2002D586B /* EdgeInsetsTweakTemplate.swift in Sources */,
 				938D5EC51BF2C6A700B834E7 /* TweakCollectionViewController.swift in Sources */,
+				D5CE0BE01DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift in Sources */,
 				937962931BFE7B0A0046E4CE /* TweakViewData.swift in Sources */,
 				939F2CDE1CB81A6800345E03 /* UIView+TweakGroupTemplateSpringAnimation.swift in Sources */,
 				939F2CDB1CB813F900345E03 /* SignedNumberTweakDefaultParameters.swift in Sources */,
@@ -541,6 +553,7 @@
 				937AA3711CB61BDE000928C5 /* FloatingTweakGroupViewController.swift in Sources */,
 				93C942591BFBDC550054811A /* TweakBinding.swift in Sources */,
 				9345EC0E1BF2B9100086AB5D /* TweakCollection.swift in Sources */,
+				D5CE0BDC1DC7DFC200F79235 /* TweakBindingIdentifier.swift in Sources */,
 				9332235B1CB84AF0002D586B /* UIEdgeInsets+EdgeInsetsTweakTemplate.swift in Sources */,
 				9356CD1F1BF16DFA00D0BBD1 /* TweaksCollectionsListViewController.swift in Sources */,
 				93212CB01CEE255F00AA85D0 /* ShadowTweakTemplate.swift in Sources */,
@@ -548,6 +561,7 @@
 				9338787E1BF6A4C5007DF1B4 /* TweakTableCell.swift in Sources */,
 				933223541CB83F0C002D586B /* BasicAnimationTweakTemplate.swift in Sources */,
 				93E777041BED4BBD003F0DE2 /* TweakLibrary.swift in Sources */,
+				D5CE0BDE1DC7E04A00F79235 /* MultiTweakBinding.swift in Sources */,
 				933223561CB8403E002D586B /* UIView+BasicAnimationTweakTemplate.swift in Sources */,
 				937962951BFE7B2C0046E4CE /* TweakStore+Sharing.swift in Sources */,
 				931A24741BFA7A3800E40192 /* TweakColorCell.swift in Sources */,
@@ -583,7 +597,9 @@
 				93A84EF31BEAE88D0022D2F3 /* Tweak.swift in Sources */,
 				B0E03A571CFF86E900BFB1E6 /* TweakDebug.swift in Sources */,
 				931472491BFFB0C800F66D20 /* UIColor+TweaksTests.swift in Sources */,
+				D5CE0BE11DC7E1FB00F79235 /* TweakBindingIdentifier.swift in Sources */,
 				931472551BFFB41700F66D20 /* TweaksBackupsListViewController.swift in Sources */,
+				D5CE0BE21DC7E1FB00F79235 /* MultiTweakBindingIdentifier.swift in Sources */,
 				939F2CCD1CB7196400345E03 /* AppTheme.swift in Sources */,
 				9314724F1BFFB41700F66D20 /* TweaksCollectionsListViewController.swift in Sources */,
 				931472541BFFB41700F66D20 /* TweakTableCell.swift in Sources */,

--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		D5CE0BE01DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDF1DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift */; };
 		D5CE0BE11DC7E1FB00F79235 /* TweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */; };
 		D5CE0BE21DC7E1FB00F79235 /* MultiTweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDF1DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift */; };
+		D5E3FEE91DC8760A00C9D648 /* MultiTweakBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -337,6 +338,7 @@
 				93A84ED21BEAE86E0022D2F3 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		93A84ED21BEAE86E0022D2F3 /* Products */ = {
 			isa = PBXGroup;
@@ -608,6 +610,7 @@
 				9314725E1BFFB41700F66D20 /* TweakGroup.swift in Sources */,
 				9314724C1BFFB41700F66D20 /* TweakWindow.swift in Sources */,
 				939F2CD01CB7197A00345E03 /* FloatingTweakGroupViewController.swift in Sources */,
+				D5E3FEE91DC8760A00C9D648 /* MultiTweakBinding.swift in Sources */,
 				931472591BFFB41700F66D20 /* TweakStore.swift in Sources */,
 				931472571BFFB41700F66D20 /* AnyTweak.swift in Sources */,
 				9314725F1BFFB41700F66D20 /* TweakStore+Sharing.swift in Sources */,

--- a/SwiftTweaks/MultiTweakBinding.swift
+++ b/SwiftTweaks/MultiTweakBinding.swift
@@ -1,0 +1,24 @@
+//
+//  MultiTweakBinding.swift
+//  SwiftTweaks
+//
+//  Created by Mathijs Kadijk on 31-10-16.
+//  Copyright © 2016 Khan Academy. All rights reserved.
+//
+
+import Foundation
+
+/// Represents a closure that should be run whenever any of the Tweaks changes.
+internal struct MultiTweakBinding {
+	let identifier: MultiTweakBindingIdentifier
+	private let binding: () -> Void
+
+	init(tweakSet: Set<AnyTweak>, binding: @escaping () -> Void) {
+		self.identifier = MultiTweakBindingIdentifier(tweakSet: tweakSet)
+		self.binding = binding
+	}
+
+	func applyBinding() {
+		binding()
+	}
+}

--- a/SwiftTweaks/MultiTweakBindingIdentifier.swift
+++ b/SwiftTweaks/MultiTweakBindingIdentifier.swift
@@ -1,0 +1,28 @@
+//
+//  MultiTweakBindingIdentifier.swift
+//  SwiftTweaks
+//
+//  Created by Mathijs Kadijk on 31-10-16.
+//  Copyright © 2016 Khan Academy. All rights reserved.
+//
+
+import Foundation
+
+/// Opaque reference to a closure bound to multiple Tweaks
+public struct MultiTweakBindingIdentifier: Hashable {
+	internal let tweakSet: Set<AnyTweak>
+	internal let identifier: UUID
+
+	internal init(tweakSet: Set<AnyTweak>) {
+		self.tweakSet = tweakSet
+		self.identifier = UUID()
+	}
+
+	public var hashValue: Int {
+		return "\(tweakSet.hashValue)\(TweakIdentifierSeparator)\(identifier)".hashValue
+	}
+}
+
+public func ==(lhs: MultiTweakBindingIdentifier, rhs: MultiTweakBindingIdentifier) -> Bool {
+	return lhs.tweakSet == rhs.tweakSet && lhs.identifier == rhs.identifier
+}

--- a/SwiftTweaks/TweakBinding.swift
+++ b/SwiftTweaks/TweakBinding.swift
@@ -8,13 +8,14 @@
 
 import Foundation
 
-/// Represents a Tweak and a closure that should be run whenever the Tweak changes.
+/// Represents a closure that should be run whenever the Tweak changes.
 internal struct TweakBinding<T: TweakableType>: TweakBindingType{
-	let tweak: Tweak<T>
-	let binding: (T) -> Void
+	let identifier: TweakBindingIdentifier
+	private let binding: (T) -> Void
 
 	init(tweak: Tweak<T>, binding: @escaping (T) -> Void) {
-		self.tweak = tweak
+		let anyTweak = AnyTweak(tweak: tweak)
+		self.identifier = TweakBindingIdentifier(tweak: anyTweak)
 		self.binding = binding
 	}
 
@@ -30,6 +31,10 @@ internal struct TweakBinding<T: TweakableType>: TweakBindingType{
 internal struct AnyTweakBinding: TweakBindingType {
 	private let tweakBinding: TweakBindingType
 
+	var identifier: TweakBindingIdentifier {
+		return tweakBinding.identifier
+	}
+
 	init(tweakBinding: TweakBindingType) {
 		self.tweakBinding = tweakBinding
 	}
@@ -41,5 +46,7 @@ internal struct AnyTweakBinding: TweakBindingType {
 
 // When combined with AnyTweakBinding, this provides our type-erasure around TweakBinding<T>
 internal protocol TweakBindingType {
+	var identifier: TweakBindingIdentifier { get }
+
 	func applyBindingWithValue(_ value: TweakableType)
 }

--- a/SwiftTweaks/TweakBindingIdentifier.swift
+++ b/SwiftTweaks/TweakBindingIdentifier.swift
@@ -1,0 +1,28 @@
+//
+//  TweakBindingIdentifier.swift
+//  SwiftTweaks
+//
+//  Created by Mathijs Kadijk on 31-10-16.
+//  Copyright © 2016 Khan Academy. All rights reserved.
+//
+
+import Foundation
+
+/// Opaque reference to a closure bound to a Tweak
+public struct TweakBindingIdentifier: Hashable {
+	internal let tweak: AnyTweak
+	internal let identifier: UUID
+
+	internal init(tweak: AnyTweak) {
+		self.tweak = tweak
+		self.identifier = UUID()
+	}
+
+	public var hashValue: Int {
+		return "\(tweak.tweakIdentifier)\(TweakIdentifierSeparator)\(identifier)".hashValue
+	}
+}
+
+public func ==(lhs: TweakBindingIdentifier, rhs: TweakBindingIdentifier) -> Bool {
+	return lhs.tweak == rhs.tweak && lhs.identifier == rhs.identifier
+}

--- a/SwiftTweaks/TweakLibrary.swift
+++ b/SwiftTweaks/TweakLibrary.swift
@@ -20,14 +20,24 @@ public extension TweakLibraryType {
 	}
 
 	/// Immediately binds the currentValue of a given tweak, and then continues to update whenever the tweak changes.
-	static func bind<T>(_ tweak: Tweak<T>, binding: @escaping (T) -> Void) {
-		self.defaultStore.bind(tweak, binding: binding)
+	static func bind<T>(_ tweak: Tweak<T>, binding: @escaping (T) -> Void) -> TweakBindingIdentifier {
+		return self.defaultStore.bind(tweak, binding: binding)
+	}
+
+	/// Unbinds the identified binding, stops delivering updates and releases the closure.
+	static func unbind(identifier: TweakBindingIdentifier) {
+		self.defaultStore.unbind(identifier)
 	}
 
 	//  Accepts a collection of Tweaks, and immediately calls the updateHandler.
 	/// The updateHandler is then re-called each time any of the collection's tweaks change.
 	/// Inside the updateHandler, you'll need to use `assign` to get the tweaks' current values.
-	static func bindMultiple(_ tweaks: [TweakType], binding: @escaping () -> Void) {
-		self.defaultStore.bindMultiple(tweaks, binding: binding)
+	static func bindMultiple(_ tweaks: [TweakType], binding: @escaping () -> Void) -> MultiTweakBindingIdentifier {
+		return self.defaultStore.bindMultiple(tweaks, binding: binding)
+	}
+
+	/// Unbinds the identified binding, stops delivering updates and releases the closure.
+	static func unbindMultiple(identifier: MultiTweakBindingIdentifier) {
+		self.defaultStore.unbindMultiple(identifier)
 	}
 }


### PR DESCRIPTION
This is an implementation of #70 (and thus also of #53). Feedback is very welcome, I had some spare time to code a solution. You probably have feedback on what is where, comments, tests and coding conventions. Feel free to update the PR or add comments so I can make some changes.

(Or even take this as inspiration/a starting point to start your own implementation.)

**Most important changes:**
- `bind` returns an opaque `TweakBindingIdentifier` as a reference to that binding
- `unbind` can be used to unregister a bound closure
-  Introduced `MultiTweakBinding` to keep logic for `bindMultiple` simple and consistent with `bind`
- `bindMultiple` returns `MultiTweakBindingIdentifier` that can be used with `unbindMultiple`

**Other small changes:**
- `tweakBindings` are now based on hashable `AnyTweak` instead of the "arbitrary" `tweak.persistenceIdentifier`
- Removed unused `tweak` property from `TweakBinding`
- Made `binding` private in `TweakBinding`

**Usage:**
```swift
let colorTintBinding = ExampleTweaks.bind(ExampleTweaks.colorTint) { button.tintColor = $0 }
// Some time later
ExampleTweaks.unbind(colorTintBinding)
```