### PR TITLE
Add `StringList` tweak type (1.x version)

### DIFF
--- a/SwiftTweaks/FloatingTweakGroupViewController.swift
+++ b/SwiftTweaks/FloatingTweakGroupViewController.swift
@@ -306,7 +306,7 @@ extension FloatingTweakGroupViewController: UITableViewDelegate {
 			let alert = UIAlertController(title: "Can't edit colors here.", message: "Sorry, haven't built out the floating UI for it yet!", preferredStyle: .Alert)
 			alert.addAction(UIAlertAction(title: "Dismiss", style: .Default, handler: nil))
 			presentViewController(alert, animated: true, completion: nil)
-		case .Boolean, .Integer, .CGFloat, .Double:
+		case .Boolean, .Integer, .CGFloat, .Double, .StringList:
 			break
 		}
 	}

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -80,7 +80,8 @@ extension Tweak where T: SignedNumberType {
 }
 
 extension Tweak {
-	// This can't be an initializer because generic types apparently can't handle fixed-type initializers
+	/// This can't be an initializer because generic types apparently can't handle fixed-type initializers.
+	/// If no default value is provided, the first item in the `options` list is used.
 	public static func stringList(collectionName: String, _ groupName: String, _ tweakName: String, options: [String], defaultValue: String?=nil) -> Tweak<StringOption> {
 		precondition(!options.isEmpty, "Options list cannot be empty (stringList tweak \"\(tweakName)\")")
 		precondition(defaultValue == nil || options.indexOf(defaultValue!) != nil,
@@ -90,7 +91,7 @@ extension Tweak {
 			collectionName: collectionName,
 			groupName: groupName,
 			tweakName: tweakName,
-			defaultValue: StringOption(value: defaultValue ?? options[0]),
+			defaultValue: StringOption(value: defaultValue ?? options.first!),
 			options: options.map(StringOption.init)
 		)
 	}

--- a/SwiftTweaks/TweakBinding.swift
+++ b/SwiftTweaks/TweakBinding.swift
@@ -20,7 +20,7 @@ internal struct TweakBinding<T: TweakableType>: TweakBindingType{
 
 	func applyBindingWithValue(value: TweakableType) {
 		switch value.dynamicType.tweakViewDataType {
-		case .Boolean, .Integer, .CGFloat, .Double, .UIColor:
+		case .Boolean, .Integer, .CGFloat, .Double, .UIColor, .StringList:
 			binding(value as! T)
 		}
 	}

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -85,7 +85,7 @@ extension TweakCollectionViewController: UITableViewDelegate {
 		case .UIColor:
 			let colorEditVC = TweakColorEditViewController(anyTweak: tweak, tweakStore: tweakStore, delegate: self)
 			navigationController?.pushViewController(colorEditVC, animated: true)
-		case .Boolean, .Integer, .CGFloat, .Double:
+		case .Boolean, .Integer, .CGFloat, .Double, .StringList:
 			break
 		}
 	}

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -166,6 +166,7 @@ private final class TweakDiskPersistency {
 			case .CGFloat: return anyObject as? CGFloat
 			case .Double: return anyObject as? Double
 			case .UIColor: return anyObject as? UIColor
+			case .StringList: return anyObject as? StringOption
 			}
 		}
 	}
@@ -180,6 +181,7 @@ private extension TweakViewDataType {
 		case .CGFloat: return "cgfloat"
 		case .Double: return "double"
 		case .UIColor: return "uicolor"
+		case .StringList: return "stringlist"
 		}
 	}
 }
@@ -193,6 +195,7 @@ private extension TweakableType {
 			case .CGFloat: return self as! CGFloat
 			case .Double: return self as! Double
 			case .UIColor: return self as! UIColor
+			case .StringList: return (self as! StringOption).value as AnyObject
 		}
 	}
 }

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -136,6 +136,9 @@ public final class TweakStore {
 		case let .Color(defaultValue: defaultValue):
 			let currentValue = cachedValue as? UIColor ?? defaultValue
 			return .Color(value: currentValue, defaultValue: defaultValue)
+		case let .StringList(defaultValue: defaultValue, options: options):
+			let currentValue = cachedValue as? StringOption ?? defaultValue
+			return .StringList(value: currentValue, defaultValue: defaultValue, options: options)
 		}
 	}
 

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -15,8 +15,9 @@ internal enum TweakViewData {
 	case Float(value: CGFloat, defaultValue: CGFloat, min: CGFloat?, max: CGFloat?, stepSize: CGFloat?)
 	case DoubleTweak(value: Double, defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case Color(value: UIColor, defaultValue: UIColor)
+	case StringList(value: StringOption, defaultValue: StringOption, options: [StringOption])
 
-	init<T: TweakableType>(type: TweakViewDataType, value: T, defaultValue: T, minimum: T?, maximum: T?, stepSize: T?) {
+	init<T: TweakableType>(type: TweakViewDataType, value: T, defaultValue: T, minimum: T?, maximum: T?, stepSize: T?, options: [T]?) {
 		switch type {
 		case .Boolean:
 			self = .Boolean(value: value as! Bool, defaultValue: defaultValue as! Bool)
@@ -31,6 +32,8 @@ internal enum TweakViewData {
 		case .Double:
 			let clippedValue = clip(value as! Double, minimum as? Double, maximum as? Double)
 			self = .DoubleTweak(value: clippedValue, defaultValue: defaultValue as! Double, min: minimum as? Double, max: maximum as? Double, stepSize: stepSize as? Double)
+		case .StringList:
+			self = .StringList(value: value as! StringOption, defaultValue: defaultValue as! StringOption, options: options!.map { $0 as! StringOption })
 		}
 	}
 
@@ -46,6 +49,8 @@ internal enum TweakViewData {
 			return doubleValue
 		case let .Color(value: colorValue, defaultValue: _):
 			return colorValue
+		case let .StringList(value: stringValue, _, _):
+			return stringValue
 		}
 	}
 
@@ -68,6 +73,9 @@ internal enum TweakViewData {
 		case let .Color(value: value, defaultValue: defaultValue):
 			string = "Color(\(value.hexString), alpha: \(value.alphaValue))"
 			differsFromDefault = (value != defaultValue)
+		case let .StringList(value: value, defaultValue: defaultValue, _):
+			string = value.value
+			differsFromDefault = string != defaultValue.value
 		}
 		return (string, differsFromDefault)
 	}
@@ -76,7 +84,7 @@ internal enum TweakViewData {
 		switch self {
 		case .Integer, .Float, .DoubleTweak:
 			return true
-		case .Boolean, .Color:
+		case .Boolean, .Color, .StringList:
 			return false
 		}
 	}
@@ -99,7 +107,7 @@ internal enum TweakViewData {
 		let maximum: Double?
 
 		switch self {
-		case .Boolean, .Color:
+		case .Boolean, .Color, .StringList:
 			return nil
 
 		case let .Integer(intValue, intDefaultValue, intMin, intMax, _):

--- a/SwiftTweaks/TweakableType.swift
+++ b/SwiftTweaks/TweakableType.swift
@@ -24,9 +24,10 @@ public enum TweakViewDataType {
 	case CGFloat
 	case Double
 	case UIColor
+	case StringList
 
 	public static let allTypes: [TweakViewDataType] = [
-		.Boolean, .Integer, .CGFloat, .Double, .UIColor
+		.Boolean, .Integer, .CGFloat, .Double, .UIColor, .StringList
 	]
 }
 
@@ -39,9 +40,29 @@ public enum TweakDefaultData {
 	case Float(defaultValue: CGFloat, min: CGFloat?, max: CGFloat?, stepSize: CGFloat?)
 	case DoubleTweak(defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case Color(defaultValue: UIColor)
+	case StringList(defaultValue: StringOption, options: [StringOption])
 }
 
 // MARK: Types that conform to TweakableType
+
+public struct StringOption {
+	public let value: String
+	init(value: String) {
+		self.value = value
+	}
+}
+
+extension StringOption: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .StringList
+	}
+}
+
+extension StringOption: Equatable {}
+
+public func ==(lhs: StringOption, rhs: StringOption) -> Bool {
+	return lhs.value == rhs.value
+}
 
 extension Bool: TweakableType {
 	public static var tweakViewDataType: TweakViewDataType {

--- a/SwiftTweaks/TweaksViewController.swift
+++ b/SwiftTweaks/TweaksViewController.swift
@@ -38,7 +38,7 @@ public final class TweaksViewController: UIViewController {
 	}
 
 	public required init?(coder aDecoder: NSCoder) {
-	    fatalError("init(coder:) has not been implemented")
+		fatalError("init(coder:) has not been implemented")
 	}
 }
 

--- a/iOS Example/iOS Example/Base.lproj/LaunchScreen.storyboard
+++ b/iOS Example/iOS Example/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,10 +18,9 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/iOS Example/iOS Example/ExampleTweaks.swift
+++ b/iOS Example/iOS Example/ExampleTweaks.swift
@@ -27,6 +27,8 @@ public struct ExampleTweaks: TweakLibraryType {
 	public static let colorText1 = Tweak("Text", "Color", "text-1", UIColor(white: 0.05, alpha: 1.0))
 	public static let colorText2 = Tweak("Text", "Color", "text-2", UIColor(white: 0.15, alpha: 1.0))
 
+    public static let title = Tweak<StringOption>.stringList("Text", "Text", "Title", options: ["SwiftTweaks", "Welcome!", "Example"])
+
 	// Tweaks are often used in combination with each other, so we have some templates available for ease-of-use:
 	public static let buttonAnimation = SpringAnimationTweakTemplate("Animation", "Button Animation", duration: 0.5) // Note: "duration" is optional, if you don't provide it, there's a sensible default!
 
@@ -52,6 +54,7 @@ public struct ExampleTweaks: TweakLibraryType {
 
 			colorText1,
 			colorText2,
+			title,
 
 			fontSizeText1,
 			fontSizeText2,

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -58,6 +58,10 @@ class ViewController: UIViewController {
 			self.titleLabel.font = UIFont.systemFontOfSize(fontSize)
 		}
 
+        ExampleTweaks.bind(ExampleTweaks.title) { (title: StringOption) in
+            self.titleLabel.text = title.value
+        }
+
 		// Now let's look at a trickier example: let's say that you have a layout, and it depends on multiple tweaks. 
 		// In our case, we have tweaks for two font sizes, as well as two layout parameters (horizontal margins and vertical padding between the labels). 
 		// What we'll do in this case is create a layout closure, and then call it each time any of those tweaks change. You could also call an existing function (like `layoutSubviews` or something like that) instead of creating a closure.


### PR DESCRIPTION
This renders a list of strings as a UISegmentedControl.

Example:
```swift
let title = Tweak<StringOption>.stringList("Text", "Text", "Title", options: ["SwiftTweaks", "Welcome!", "Example"])
```

`defaultValue` is optional, and defaults to the first item in `options`.

TODO in the future:
- for lots of strings, make a version that renders the list vertically,
  or that uses a picker view
- make an `enumList` tweak type, for choosing between options of a enum