### PR TITLE
Changed UIColor extension because it can conflict with other frameworks.

### DIFF
--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		930ECDB81DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930ECDB71DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift */; };
-		931472491BFFB0C800F66D20 /* UIColor+TweaksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931472481BFFB0C800F66D20 /* UIColor+TweaksTests.swift */; };
+		931472491BFFB0C800F66D20 /* TweaksColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931472481BFFB0C800F66D20 /* TweaksColorTests.swift */; };
 		9314724C1BFFB41700F66D20 /* TweakWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A3AF311BF1677B00CAD43B /* TweakWindow.swift */; };
 		9314724D1BFFB41700F66D20 /* TweaksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AA34561BEBC654004B734B /* TweaksViewController.swift */; };
 		9314724E1BFFB41700F66D20 /* TweaksRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9345EC081BF2A0490086AB5D /* TweaksRootViewController.swift */; };
@@ -29,7 +29,7 @@
 		9314725D1BFFB41700F66D20 /* TweakCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9345EC0D1BF2B9100086AB5D /* TweakCollection.swift */; };
 		9314725E1BFFB41700F66D20 /* TweakGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9345EC0F1BF2B95C0086AB5D /* TweakGroup.swift */; };
 		9314725F1BFFB41700F66D20 /* TweakStore+Sharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937962941BFE7B2C0046E4CE /* TweakStore+Sharing.swift */; };
-		931472601BFFB41700F66D20 /* UIColor+Tweaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932BA9D31BFA398A001ADFC6 /* UIColor+Tweaks.swift */; };
+		931472601BFFB41700F66D20 /* TweaksColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932BA9D31BFA398A001ADFC6 /* TweaksColor.swift */; };
 		931472611BFFB41700F66D20 /* Clip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9379628E1BFE509F0046E4CE /* Clip.swift */; };
 		931A24721BFA77FB00E40192 /* TweakColorEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931A24711BFA77FB00E40192 /* TweakColorEditViewController.swift */; };
 		931A24741BFA7A3800E40192 /* TweakColorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931A24731BFA7A3800E40192 /* TweakColorCell.swift */; };
@@ -38,7 +38,7 @@
 		931A24801BFA95B000E40192 /* TweakPersistency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931A247F1BFA95B000E40192 /* TweakPersistency.swift */; };
 		93212CB01CEE255F00AA85D0 /* ShadowTweakTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93212CAF1CEE255F00AA85D0 /* ShadowTweakTemplate.swift */; };
 		93212CB21CEE258900AA85D0 /* CALayer+ShadowTweakTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93212CB11CEE258900AA85D0 /* CALayer+ShadowTweakTemplate.swift */; };
-		932BA9D41BFA398A001ADFC6 /* UIColor+Tweaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932BA9D31BFA398A001ADFC6 /* UIColor+Tweaks.swift */; };
+		932BA9D41BFA398A001ADFC6 /* TweaksColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932BA9D31BFA398A001ADFC6 /* TweaksColor.swift */; };
 		933223541CB83F0C002D586B /* BasicAnimationTweakTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933223531CB83F0C002D586B /* BasicAnimationTweakTemplate.swift */; };
 		933223561CB8403E002D586B /* UIView+BasicAnimationTweakTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933223551CB8403E002D586B /* UIView+BasicAnimationTweakTemplate.swift */; };
 		933223591CB842D2002D586B /* EdgeInsetsTweakTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933223581CB842D2002D586B /* EdgeInsetsTweakTemplate.swift */; };
@@ -115,7 +115,7 @@
 		5752FECE1C05392300AEECD1 /* iOS-Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "iOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		5752FECF1C05392300AEECD1 /* iOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "iOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
 		930ECDB71DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TweakViewData+TweaksTests.swift"; sourceTree = "<group>"; };
-		931472481BFFB0C800F66D20 /* UIColor+TweaksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+TweaksTests.swift"; sourceTree = "<group>"; };
+		931472481BFFB0C800F66D20 /* TweaksColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweaksColorTests.swift; sourceTree = "<group>"; };
 		931A24711BFA77FB00E40192 /* TweakColorEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakColorEditViewController.swift; sourceTree = "<group>"; };
 		931A24731BFA7A3800E40192 /* TweakColorCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakColorCell.swift; sourceTree = "<group>"; };
 		931A24751BFA7EEE00E40192 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
@@ -123,7 +123,7 @@
 		931A247F1BFA95B000E40192 /* TweakPersistency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakPersistency.swift; sourceTree = "<group>"; };
 		93212CAF1CEE255F00AA85D0 /* ShadowTweakTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadowTweakTemplate.swift; sourceTree = "<group>"; };
 		93212CB11CEE258900AA85D0 /* CALayer+ShadowTweakTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CALayer+ShadowTweakTemplate.swift"; sourceTree = "<group>"; };
-		932BA9D31BFA398A001ADFC6 /* UIColor+Tweaks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Tweaks.swift"; sourceTree = "<group>"; };
+		932BA9D31BFA398A001ADFC6 /* TweaksColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweaksColor.swift; sourceTree = "<group>"; };
 		933223531CB83F0C002D586B /* BasicAnimationTweakTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicAnimationTweakTemplate.swift; sourceTree = "<group>"; };
 		933223551CB8403E002D586B /* UIView+BasicAnimationTweakTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+BasicAnimationTweakTemplate.swift"; sourceTree = "<group>"; };
 		933223581CB842D2002D586B /* EdgeInsetsTweakTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgeInsetsTweakTemplate.swift; sourceTree = "<group>"; };
@@ -356,7 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				93A84EE01BEAE86E0022D2F3 /* SwiftTweaksTests.swift */,
-				931472481BFFB0C800F66D20 /* UIColor+TweaksTests.swift */,
+				931472481BFFB0C800F66D20 /* TweaksColorTests.swift */,
 				939F2CCB1CB715E800345E03 /* Clipping+TweaksTest.swift */,
 				93478C7B1CBDF03A0064D8AD /* Precision+TweaksTests.swift */,
 				939F2CD11CB71AC900345E03 /* Tweak+TweaksTests.swift */,
@@ -397,7 +397,7 @@
 			isa = PBXGroup;
 			children = (
 				93A84EEB1BEAE88D0022D2F3 /* HashingUtilities.swift */,
-				932BA9D31BFA398A001ADFC6 /* UIColor+Tweaks.swift */,
+				932BA9D31BFA398A001ADFC6 /* TweaksColor.swift */,
 				9379628E1BFE509F0046E4CE /* Clip.swift */,
 				93B058E21CC44D8900AB2759 /* Precision.swift */,
 				9338E9E61CB57068002A92BE /* UIImage+SwiftTweaks.swift */,
@@ -554,7 +554,7 @@
 				937AA36F1CB5D6DA000928C5 /* HitTransparentWindow.swift in Sources */,
 				93212CB21CEE258900AA85D0 /* CALayer+ShadowTweakTemplate.swift in Sources */,
 				93A3AF321BF1677B00CAD43B /* TweakWindow.swift in Sources */,
-				932BA9D41BFA398A001ADFC6 /* UIColor+Tweaks.swift in Sources */,
+				932BA9D41BFA398A001ADFC6 /* TweaksColor.swift in Sources */,
 				B0E03A551CFF818900BFB1E6 /* TweakDebug.swift in Sources */,
 				939F2CD51CB8097D00345E03 /* TweakGroupTemplateType.swift in Sources */,
 				939F2CE01CB81ED400345E03 /* TweakClusterType.swift in Sources */,
@@ -582,7 +582,7 @@
 				9314725C1BFFB41700F66D20 /* TweakPersistency.swift in Sources */,
 				93A84EF31BEAE88D0022D2F3 /* Tweak.swift in Sources */,
 				B0E03A571CFF86E900BFB1E6 /* TweakDebug.swift in Sources */,
-				931472491BFFB0C800F66D20 /* UIColor+TweaksTests.swift in Sources */,
+				931472491BFFB0C800F66D20 /* TweaksColorTests.swift in Sources */,
 				931472551BFFB41700F66D20 /* TweaksBackupsListViewController.swift in Sources */,
 				939F2CCD1CB7196400345E03 /* AppTheme.swift in Sources */,
 				9314724F1BFFB41700F66D20 /* TweaksCollectionsListViewController.swift in Sources */,
@@ -602,7 +602,7 @@
 				931472501BFFB41700F66D20 /* TweakCollectionViewController.swift in Sources */,
 				9314725A1BFFB41700F66D20 /* TweakBinding.swift in Sources */,
 				939F2CCC1CB715E800345E03 /* Clipping+TweaksTest.swift in Sources */,
-				931472601BFFB41700F66D20 /* UIColor+Tweaks.swift in Sources */,
+				931472601BFFB41700F66D20 /* TweaksColor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftTweaks/AppTheme.swift
+++ b/SwiftTweaks/AppTheme.swift
@@ -14,17 +14,17 @@ internal struct AppTheme {
 		fileprivate struct Palette {
 			static let whiteColor = UIColor.white
 			static let blackColor = UIColor.black
-			static let grayColor = UIColor(hex: 0x8E8E93)
-			static let pageBackground1 = UIColor(hex: 0xF8F8F8)
+			static let grayColor = TweaksColor.color(withHex: 0x8E8E93)
+			static let pageBackground1 = TweaksColor.color(withHex: 0xF8F8F8)
 
-			static let tintColor = UIColor(hex: 0x007AFF)
-			static let tintColorPressed = UIColor(hex: 0x084BC1)
+			static let tintColor = TweaksColor.color(withHex: 0x007AFF)
+			static let tintColorPressed = TweaksColor.color(withHex: 0x084BC1)
 			static let controlGrayscale = UIColor.darkGray
 
-			static let secondaryControl = UIColor(hex: 0xC8C7CC)
-			static let secondaryControlPressed = UIColor(hex: 0xAFAFB3)
+			static let secondaryControl = TweaksColor.color(withHex: 0xC8C7CC)
+			static let secondaryControlPressed = TweaksColor.color(withHex: 0xAFAFB3)
 
-			static let destructiveRed = UIColor(hex: 0xC90911)
+			static let destructiveRed = TweaksColor.color(withHex: 0xC90911)
 		}
 
 		static let sectionHeaderTitleColor = Palette.grayColor

--- a/SwiftTweaks/ColorRepresentation.swift
+++ b/SwiftTweaks/ColorRepresentation.swift
@@ -41,7 +41,7 @@ extension ColorRepresentation {
 	var color: UIColor {
 		switch self {
 		case let .hex(hex: hex, alpha: alpha):
-			return UIColor.colorWithHexString(hex)!.withAlphaComponent(CGFloat(alpha.rawValue))
+			return TweaksColor.colorWithHexString(hex)!.withAlphaComponent(CGFloat(alpha.rawValue))
 		case let .rgBa(r: r, g: g, b: b, a: a):
 			return UIColor(red: r.rawValue, green: g.rawValue, blue: b.rawValue, alpha: a.rawValue)
 		case let .hsBa(h: h, s: s, b: b, a: a):
@@ -57,7 +57,7 @@ extension ColorRepresentation {
 			color.getWhite(&white, alpha: &alpha)
 
 			self = .hex(
-				hex: color.hexString,
+				hex: TweaksColor.hexString(fromColor: color),
 				alpha: ColorComponentNumerical(type: .alpha, rawValue: alpha)
 			)
 		case .rgBa:

--- a/SwiftTweaks/TweakColorCell.swift
+++ b/SwiftTweaks/TweakColorCell.swift
@@ -143,8 +143,8 @@ extension TweakColorCell: UITextFieldDelegate {
 	}
 
 	func textFieldDidEndEditing(_ textField: UITextField) {
-		if let text = textField.text, let newValue = UIColor.colorWithHexString(text) {
-			viewData = .hexComponent(newValue.hexString)
+		if let text = textField.text, let newValue = TweaksColor.colorWithHexString(text) {
+			viewData = .hexComponent(TweaksColor.hexString(fromColor: newValue))
 			delegate?.tweakColorCellDidChangeValue(self)
 		} else {
 			updateSubviews()

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -222,7 +222,7 @@ internal final class TweakTableCell: UITableViewCell {
 
 		case let .color(value: value, _):
 			colorChit.backgroundColor = value
-			textField.text = value.hexString
+			textField.text = TweaksColor.hexString(fromColor: value)
 			textFieldEnabled = false
 		}
 
@@ -304,7 +304,7 @@ extension TweakTableCell: UITextFieldDelegate {
 				updateSubviews()
 			}
 		case let .color(_, defaultValue: defaultValue):
-			if let text = textField.text, let newValue = UIColor.colorWithHexString(text) {
+			if let text = textField.text, let newValue = TweaksColor.colorWithHexString(text) {
 				viewData = TweakViewData(type: .uiColor, value: newValue, defaultValue: defaultValue, minimum: nil, maximum: nil, stepSize: nil)
 				delegate?.tweakCellDidChangeCurrentValue(self)
 			} else {

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -80,7 +80,7 @@ internal enum TweakViewData {
 			string = "Double(\(value))"
 			differsFromDefault = (value != defaultValue)
 		case let .color(value: value, defaultValue: defaultValue):
-			string = "Color(\(value.hexString), alpha: \(value.alphaValue))"
+            string = "Color(\(TweaksColor.hexString(fromColor: value)), alpha: \(TweaksColor.alphaValue(fromColor: value)))"
 			differsFromDefault = (value != defaultValue)
 		}
 		return (string, differsFromDefault)

--- a/SwiftTweaks/TweaksColor.swift
+++ b/SwiftTweaks/TweaksColor.swift
@@ -1,5 +1,5 @@
 //
-//  UIColor+Tweaks.swift
+//  TweaksColor.swift
 //  SwiftTweaks
 //
 //  Created by Bryan Clark on 11/16/15.
@@ -10,7 +10,7 @@ import UIKit
 
 // info via http://arstechnica.com/apple/2009/02/iphone-development-accessing-uicolor-components/
 
-internal extension UIColor {
+struct TweaksColor {
 
 	/// Creates a UIColor with a given hex string (e.g. "#FF00FF")
 	// NOTE: Would use a failable init (e.g. `UIColor(hexString: _)` but have to wait until Swift 2.2.1 https://github.com/Khan/SwiftTweaks/issues/38
@@ -47,8 +47,8 @@ internal extension UIColor {
 		return UIColor(red: colorFloats[0], green: colorFloats[1], blue: colorFloats[2], alpha: colorFloats[3])
 	}
 
-	internal convenience init(hex: UInt32, alpha: CGFloat = 1) {
-		self.init(
+    internal static func color(withHex hex: UInt32, alpha: CGFloat = 1) -> UIColor {
+        return UIColor(
 			red: CGFloat((hex & 0xFF0000) >> 16) / 255.0,
 			green: CGFloat((hex & 0x00FF00) >> 8) / 255.0,
 			blue: CGFloat((hex & 0x0000FF)) / 255.0,
@@ -56,21 +56,21 @@ internal extension UIColor {
 		)
 	}
 
-	internal var alphaValue: CGFloat {
+    internal static func alphaValue(fromColor color: UIColor) -> CGFloat {
 		var white: CGFloat = 0
 		var alpha: CGFloat = 0
-		getWhite(&white, alpha: &alpha)
+		color.getWhite(&white, alpha: &alpha)
 		return alpha
 	}
 
-	internal var hexString: String {
-		assert(canProvideRGBComponents, "Must be an RGB color to use UIColor.hexValue")
+	internal static func hexString(fromColor color: UIColor) -> String {
+		assert(canProvideRGBComponents(fromColor: color), "Must be an RGB color to use UIColor.hexValue")
 
 		var red: CGFloat = 0
 		var green: CGFloat = 0
 		var blue: CGFloat = 0
 		var alpha: CGFloat = 0
-		getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+		color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
 		return String(format: "#%02x%02x%02x", arguments: [
 			Int(red * 255.0),
@@ -79,8 +79,8 @@ internal extension UIColor {
 			]).uppercased()
 	}
 
-	private var canProvideRGBComponents: Bool {
-		switch self.cgColor.colorSpace!.model {
+	internal static func canProvideRGBComponents(fromColor color: UIColor) -> Bool {
+		switch color.cgColor.colorSpace!.model {
 		case .rgb, .monochrome:
 			return true
 		default:

--- a/SwiftTweaksTests/TweaksColorTests.swift
+++ b/SwiftTweaksTests/TweaksColorTests.swift
@@ -19,14 +19,14 @@ class UIColor_TweaksTests: XCTestCase {
 		let expectedColor: UIColor?
 
 		static func verify(_ testCase: HexToColorTestCase) {
-			if let generatedColor = UIColor.colorWithHexString(testCase.string) {
+			if let generatedColor = TweaksColor.colorWithHexString(testCase.string) {
 				if let expectedColor = testCase.expectedColor {
-					XCTAssertEqual(generatedColor.hexString, expectedColor.hexString, "Generated color with hex \(generatedColor.hexString) from test string \(testCase.string), but expected color with hex \(expectedColor.hexString)")
+					XCTAssertEqual(TweaksColor.hexString(fromColor: generatedColor), TweaksColor.hexString(fromColor: expectedColor), "Generated color with hex \(TweaksColor.hexString(fromColor: generatedColor)) from test string \(testCase.string), but expected color with hex \(TweaksColor.hexString(fromColor: expectedColor))")
 				} else {
 					XCTFail("Generated a color from hex string \(testCase.string), but expected no color.")
 				}
 			} else if let expectedColor = testCase.expectedColor {
-				XCTFail("Failed to generate expected color: \(expectedColor.hexString) from hex string \(testCase.string)")
+				XCTFail("Failed to generate expected color: \(TweaksColor.hexString(fromColor: expectedColor)) from hex string \(testCase.string)")
 			}
 		}
 	}
@@ -71,7 +71,7 @@ class UIColor_TweaksTests: XCTestCase {
 		let expectedHex: String
 
 		static func verify(_ testCase: ColorToHexTestCase) {
-			XCTAssertEqual(testCase.color.hexString, testCase.expectedHex, "Expected color \(testCase.color) to generate #\(testCase.expectedHex)")
+			XCTAssertEqual(TweaksColor.hexString(fromColor: testCase.color), testCase.expectedHex, "Expected color \(testCase.color) to generate #\(testCase.expectedHex)")
 		}
 	}
 


### PR DESCRIPTION
Changed to a struct with static functions. Using and extension with functions such as UIColor(hex:) is a very common pattern and can conflict with other frameworks. This change takes out the extension and uses a struct with a ‘Tweaks’ prefix on the struct name.