### PR TITLE
Remove decimal value for `Int` tweak

### DIFF
--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -208,7 +208,7 @@ internal final class TweakTableCell: UITableViewCell {
 			let doubleValue = viewData.doubleValue!
 			self.updateStepper(value: doubleValue, stepperValues: viewData.stepperValues!)
 
-			textField.text = String(doubleValue)
+			textField.text = String(describing: viewData.value)
 			textField.keyboardType = .numberPad
 			textFieldEnabled = true
 

--- a/SwiftTweaksTests/Precision+TweaksTests.swift
+++ b/SwiftTweaksTests/Precision+TweaksTests.swift
@@ -56,12 +56,12 @@ class Precision_TweaksTests: XCTestCase {
 
 		// Double
 		tests
-			.map { return PrecisionTestCase($0, $1, $2, DBL_EPSILON) }
+			.map { PrecisionTestCase($0, $1, $2, DBL_EPSILON) }
 			.forEach(PrecisionTestCase.verify)
 
 		// CGFloat
 		tests
-			.map { return PrecisionTestCase(CGFloat($0), $1, CGFloat($2), CGFloat(FLT_EPSILON)) }
+			.map { PrecisionTestCase(CGFloat($0), $1, CGFloat($2), CGFloat(FLT_EPSILON)) }
 			.forEach(PrecisionTestCase.verify)
 	}
 }

--- a/SwiftTweaksTests/TweakViewData+TweaksTests.swift
+++ b/SwiftTweaksTests/TweakViewData+TweaksTests.swift
@@ -33,9 +33,9 @@ class TweakViewData_TweaksTests: XCTestCase {
 			return .float(
 				value: CGFloat(currentValue),
 				defaultValue: CGFloat(defaultValue),
-				min: customMin.map {CGFloat.init($0) },
-				max: customMax.map {CGFloat.init($0) },
-				stepSize: customStep.map {CGFloat.init($0) }
+				min: customMin.map { CGFloat.init($0) },
+				max: customMax.map { CGFloat.init($0) },
+				stepSize: customStep.map { CGFloat.init($0) }
 			)
 		}
 
@@ -119,7 +119,7 @@ class TweakViewData_TweaksTests: XCTestCase {
 		]
 
 		tests
-			.map { return StepperTestCase(
+			.map { StepperTestCase(
 				defaultValue: $0,
 				currentValue: $0, // NOTE: We don't currently care about currentValue for stepSize calculations.
 				customMin: $1,
@@ -150,7 +150,7 @@ class TweakViewData_TweaksTests: XCTestCase {
 			]
 
 		tests
-			.map { return StepperTestCase(
+			.map { StepperTestCase(
 				defaultValue: Double($0),
 				currentValue: Double($0), // NOTE: We don't currently care about currentValue for stepSize calculations.
 				customMin: $1.map(Double.init),
@@ -194,14 +194,14 @@ class TweakViewData_TweaksTests: XCTestCase {
 
 		tests
 			.map { test in
-				return StepperTestCase(
-				defaultValue: test.def,
-				currentValue: test.current,
-				customMin: test.min,
-				customMax: test.max,
-				customStep: nil,
-				expectedStep: nil,
-				expectedBounds: test.expected
+				StepperTestCase(
+  				defaultValue: test.def,
+  				currentValue: test.current,
+  				customMin: test.min,
+  				customMax: test.max,
+  				customStep: nil,
+  				expectedStep: nil,
+  				expectedBounds: test.expected
 				)
 			}
 			.forEach(StepperTestCase.verifyStepperBoundsTestCase)

--- a/SwiftTweaksTests/TweakViewData+TweaksTests.swift
+++ b/SwiftTweaksTests/TweakViewData+TweaksTests.swift
@@ -195,13 +195,13 @@ class TweakViewData_TweaksTests: XCTestCase {
 		tests
 			.map { test in
 				StepperTestCase(
-  				defaultValue: test.def,
-  				currentValue: test.current,
-  				customMin: test.min,
-  				customMax: test.max,
-  				customStep: nil,
-  				expectedStep: nil,
-  				expectedBounds: test.expected
+					defaultValue: test.def,
+					currentValue: test.current,
+					customMin: test.min,
+					customMax: test.max,
+					customStep: nil,
+					expectedStep: nil,
+					expectedBounds: test.expected
 				)
 			}
 			.forEach(StepperTestCase.verifyStepperBoundsTestCase)

--- a/SwiftTweaksTests/UIColor+TweaksTests.swift
+++ b/SwiftTweaksTests/UIColor+TweaksTests.swift
@@ -56,12 +56,12 @@ class UIColor_TweaksTests: XCTestCase {
 			HexToColorTestCase(string: "111", expectedColor: nil),
 		]
 
-		testCases.forEach { HexToColorTestCase.verify($0) }
+		testCases.forEach(HexToColorTestCase.verify)
 
 		// Re-run tests, prepending a "#" to each string.
 		testCases
-			.map { return HexToColorTestCase(string: "#"+$0.string, expectedColor: $0.expectedColor) }
-			.forEach { HexToColorTestCase.verify($0) }
+			.map { HexToColorTestCase(string: "#"+$0.string, expectedColor: $0.expectedColor) }
+			.forEach(HexToColorTestCase.verify)
 	}
 
 
@@ -89,7 +89,7 @@ class UIColor_TweaksTests: XCTestCase {
 			ColorToHexTestCase(color: UIColor.white.withAlphaComponent(1.0), expectedHex: "#FFFFFF")
 		]
 
-		testCases.forEach { ColorToHexTestCase.verify($0) }
+		testCases.forEach(ColorToHexTestCase.verify)
 
 	}
 }


### PR DESCRIPTION
Hi this patch includes these:
- Remove decimal value for `Int` tweak by using the `TweakViewData` internal value representation
- Fix some inconsistencies in test case

Related issue #76 