### PR TITLE
Feature/callback tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently, you can tweak the following types:
 - `CGFloat`
 - `Double`
 - `UIColor`
+- [`TweakCallbacks`](#callbacks)
 
 A `Tweak` looks like this:
 ```swift
@@ -56,6 +57,30 @@ public static let edgeInsets = EdgeInsetsTweakTemplate("Layout", "Screen Edge In
 Of course, you can create your own `TweakGroupTemplate` type if you'd like - they're handy whenever you have a cluster of tweaks that need to be used together to get a desired effect. They can be built out of any combination of `Tweak`s.
 
 ![Tweaks](https://github.com/Khan/SwiftTweaks/blob/master/Images/SwiftTweaks%20Demo.gif?raw=true)
+
+### Callbacks
+
+SwiftTweaks now supports callbacks. If you need to execute more complicated operations or operations that do not depend on data from certain tweak value.
+You can use `TweakCallbacks` as a type in your `TweakStore` to create a Tweak that executed your custom callbacks.
+
+```swift
+public static let action = Tweak<TweakCallbacks>("Actions", "Action", "Perform some action")
+```
+
+Later in the code you can add callbacks to that tweak, which are executed when a button in Tweaks window is pressed.
+
+```swift
+let idenfitier = ExampleTweaks.action.addCallback {
+	/// Some complicated action happens here
+	print("We're all done!")
+}
+```
+
+If you want to, you can also always remove callback using unique idenfitier that `addCallback` method provides.
+
+```swift
+ExampleTweaks.action.removeCallback(with: idenfitier)
+```
 
 ### Wait, what about [Facebook Tweaks](https://github.com/facebook/Tweaks)?
 Good question! I’m glad you asked. **The whole reason SwiftTweaks exists is because we love the stuffing out of FBTweaks.** We’re long-time fans of FBTweaks in our Objective-C projects: Replace the magic numbers with an `FBTweak` macro, and you’re all set! You can leave an FBTweak macro in your production code, because it’s replaced at compile-time with the tweak’s default value.
@@ -112,15 +137,15 @@ button.tintColor = UIColor.green
 ```
 
 **assign** returns the current value of the tweak:
-```swift	
+```swift
 button.tintColor = ExampleTweaks.assign(ExampleTweaks.colorTint)
 ```
 **bind** calls its closure immediately, and again each time the tweak changes:
-```swift	
+```swift
 ExampleTweaks.bind(ExampleTweaks.colorTint) { button.tintColor = $0 }
 ```
 **bindMultiple** calls its closure immediately, and again each time any of its tweaks change:
-```swift	
+```swift
 // A "multipleBind" is called initially, and each time _any_ of the included tweaks change:
 let tweaksToWatch: [TweakType] = [ExampleTweaks.marginHorizontal, ExampleTweaks.marginVertical]
 ExampleTweaks.bindMultiple(tweaksToWatch) {

--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		93DB80351BFCE4E80031D61A /* AnyTweak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DB80341BFCE4E80031D61A /* AnyTweak.swift */; };
 		93E777041BED4BBD003F0DE2 /* TweakLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */; };
 		AA356AF01EB3B5A90063F4E2 /* TweakCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */; };
+		AA356AF21EB3B7730063F4E2 /* TweakButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AF11EB3B7730063F4E2 /* TweakButton.swift */; };
 		B0E03A551CFF818900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		B0E03A571CFF86E900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		D5CE0BDC1DC7DFC200F79235 /* TweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */; };
@@ -164,6 +165,7 @@
 		93DB80341BFCE4E80031D61A /* AnyTweak.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyTweak.swift; sourceTree = "<group>"; };
 		93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakLibrary.swift; sourceTree = "<group>"; };
 		AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakCallbacks.swift; sourceTree = "<group>"; };
+		AA356AF11EB3B7730063F4E2 /* TweakButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakButton.swift; sourceTree = "<group>"; };
 		B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakDebug.swift; sourceTree = "<group>"; };
 		D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakBindingIdentifier.swift; sourceTree = "<group>"; };
 		D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTweakBinding.swift; sourceTree = "<group>"; };
@@ -254,6 +256,7 @@
 				939482B81BFFD89400ADBFE0 /* TweakBackup.swift */,
 				937AA36E1CB5D6DA000928C5 /* HitTransparentWindow.swift */,
 				937AA3701CB61BDE000928C5 /* FloatingTweakGroupViewController.swift */,
+				AA356AF11EB3B7730063F4E2 /* TweakButton.swift */,
 			);
 			name = Internal;
 			sourceTree = "<group>";
@@ -492,6 +495,7 @@
 				933223591CB842D2002D586B /* EdgeInsetsTweakTemplate.swift in Sources */,
 				938D5EC51BF2C6A700B834E7 /* TweakCollectionViewController.swift in Sources */,
 				D5CE0BE01DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift in Sources */,
+				AA356AF21EB3B7730063F4E2 /* TweakButton.swift in Sources */,
 				937962931BFE7B0A0046E4CE /* TweakViewData.swift in Sources */,
 				939F2CDE1CB81A6800345E03 /* UIView+TweakGroupTemplateSpringAnimation.swift in Sources */,
 				939F2CDB1CB813F900345E03 /* ComparableTweakDefaultParameters.swift in Sources */,

--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		93C942591BFBDC550054811A /* TweakBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C942581BFBDC550054811A /* TweakBinding.swift */; };
 		93DB80351BFCE4E80031D61A /* AnyTweak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DB80341BFCE4E80031D61A /* AnyTweak.swift */; };
 		93E777041BED4BBD003F0DE2 /* TweakLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */; };
+		AA356AF01EB3B5A90063F4E2 /* TweakCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */; };
 		B0E03A551CFF818900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		B0E03A571CFF86E900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		D5CE0BDC1DC7DFC200F79235 /* TweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */; };
@@ -162,6 +163,7 @@
 		93C942581BFBDC550054811A /* TweakBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakBinding.swift; sourceTree = "<group>"; };
 		93DB80341BFCE4E80031D61A /* AnyTweak.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyTweak.swift; sourceTree = "<group>"; };
 		93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakLibrary.swift; sourceTree = "<group>"; };
+		AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakCallbacks.swift; sourceTree = "<group>"; };
 		B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakDebug.swift; sourceTree = "<group>"; };
 		D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakBindingIdentifier.swift; sourceTree = "<group>"; };
 		D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTweakBinding.swift; sourceTree = "<group>"; };
@@ -317,7 +319,7 @@
 		93A84EFA1BEAE8940022D2F3 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				93AA34581BEC0EF9004B734B /* TweakableType.swift */,
+				AA356AEE1EB3B5990063F4E2 /* Types */,
 				93A84EEC1BEAE88D0022D2F3 /* Tweak.swift */,
 				939F2CDF1CB81ED400345E03 /* TweakClusterType.swift */,
 				939F2CDA1CB813F900345E03 /* ComparableTweakDefaultParameters.swift */,
@@ -354,6 +356,15 @@
 				9338E9EC1CB575AF002A92BE /* AppTheme.swift */,
 			);
 			name = Utilities;
+			sourceTree = "<group>";
+		};
+		AA356AEE1EB3B5990063F4E2 /* Types */ = {
+			isa = PBXGroup;
+			children = (
+				93AA34581BEC0EF9004B734B /* TweakableType.swift */,
+				AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */,
+			);
+			name = Types;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -495,6 +506,7 @@
 				D5CE0BDC1DC7DFC200F79235 /* TweakBindingIdentifier.swift in Sources */,
 				9332235B1CB84AF0002D586B /* UIEdgeInsets+EdgeInsetsTweakTemplate.swift in Sources */,
 				9356CD1F1BF16DFA00D0BBD1 /* TweaksCollectionsListViewController.swift in Sources */,
+				AA356AF01EB3B5A90063F4E2 /* TweakCallbacks.swift in Sources */,
 				93212CB01CEE255F00AA85D0 /* ShadowTweakTemplate.swift in Sources */,
 				93B058E31CC44D8900AB2759 /* Precision.swift in Sources */,
 				9338787E1BF6A4C5007DF1B4 /* TweakTableCell.swift in Sources */,

--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -89,6 +89,9 @@
 		93E777041BED4BBD003F0DE2 /* TweakLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */; };
 		AA356AF01EB3B5A90063F4E2 /* TweakCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */; };
 		AA356AF21EB3B7730063F4E2 /* TweakButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AF11EB3B7730063F4E2 /* TweakButton.swift */; };
+		AA356AF41EB3C5B40063F4E2 /* TweakCallbacksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AF31EB3C5B40063F4E2 /* TweakCallbacksTests.swift */; };
+		AA356AF51EB3C5FC0063F4E2 /* TweakCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */; };
+		AA356AF61EB3C6550063F4E2 /* TweakButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AF11EB3B7730063F4E2 /* TweakButton.swift */; };
 		B0E03A551CFF818900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		B0E03A571CFF86E900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		D5CE0BDC1DC7DFC200F79235 /* TweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */; };
@@ -166,6 +169,7 @@
 		93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakLibrary.swift; sourceTree = "<group>"; };
 		AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakCallbacks.swift; sourceTree = "<group>"; };
 		AA356AF11EB3B7730063F4E2 /* TweakButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakButton.swift; sourceTree = "<group>"; };
+		AA356AF31EB3C5B40063F4E2 /* TweakCallbacksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakCallbacksTests.swift; sourceTree = "<group>"; };
 		B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakDebug.swift; sourceTree = "<group>"; };
 		D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakBindingIdentifier.swift; sourceTree = "<group>"; };
 		D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTweakBinding.swift; sourceTree = "<group>"; };
@@ -314,6 +318,7 @@
 				93478C7B1CBDF03A0064D8AD /* Precision+TweaksTests.swift */,
 				939F2CD11CB71AC900345E03 /* Tweak+TweaksTests.swift */,
 				930ECDB71DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift */,
+				AA356AF31EB3C5B40063F4E2 /* TweakCallbacksTests.swift */,
 				93A84EE21BEAE86E0022D2F3 /* Info.plist */,
 			);
 			path = SwiftTweaksTests;
@@ -540,6 +545,7 @@
 				93A84EE11BEAE86E0022D2F3 /* SwiftTweaksTests.swift in Sources */,
 				930ECDB81DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift in Sources */,
 				93B058D71CBDF58500AB2759 /* TweakClusterType.swift in Sources */,
+				AA356AF51EB3C5FC0063F4E2 /* TweakCallbacks.swift in Sources */,
 				939F2CCF1CB7197800345E03 /* HitTransparentWindow.swift in Sources */,
 				931472511BFFB41700F66D20 /* TweakColorEditViewController.swift in Sources */,
 				931472611BFFB41700F66D20 /* Clip.swift in Sources */,
@@ -558,6 +564,7 @@
 				939F2CCD1CB7196400345E03 /* AppTheme.swift in Sources */,
 				9314724F1BFFB41700F66D20 /* TweaksCollectionsListViewController.swift in Sources */,
 				931472541BFFB41700F66D20 /* TweakTableCell.swift in Sources */,
+				AA356AF61EB3C6550063F4E2 /* TweakButton.swift in Sources */,
 				93A84EF11BEAE88D0022D2F3 /* HashingUtilities.swift in Sources */,
 				931472581BFFB41700F66D20 /* TweakLibrary.swift in Sources */,
 				9314725E1BFFB41700F66D20 /* TweakGroup.swift in Sources */,
@@ -574,6 +581,7 @@
 				931472501BFFB41700F66D20 /* TweakCollectionViewController.swift in Sources */,
 				9314725A1BFFB41700F66D20 /* TweakBinding.swift in Sources */,
 				939F2CCC1CB715E800345E03 /* Clipping+TweaksTest.swift in Sources */,
+				AA356AF41EB3C5B40063F4E2 /* TweakCallbacksTests.swift in Sources */,
 				931472601BFFB41700F66D20 /* UIColor+Tweaks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		AA356AF41EB3C5B40063F4E2 /* TweakCallbacksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AF31EB3C5B40063F4E2 /* TweakCallbacksTests.swift */; };
 		AA356AF51EB3C5FC0063F4E2 /* TweakCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */; };
 		AA356AF61EB3C6550063F4E2 /* TweakButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AF11EB3B7730063F4E2 /* TweakButton.swift */; };
+		AA3BD55A1F2E6B1D007912C0 /* TweakButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3BD5591F2E6B1D007912C0 /* TweakButtonTests.swift */; };
 		B0E03A551CFF818900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		B0E03A571CFF86E900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		D5CE0BDC1DC7DFC200F79235 /* TweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */; };
@@ -170,6 +171,7 @@
 		AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakCallbacks.swift; sourceTree = "<group>"; };
 		AA356AF11EB3B7730063F4E2 /* TweakButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakButton.swift; sourceTree = "<group>"; };
 		AA356AF31EB3C5B40063F4E2 /* TweakCallbacksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakCallbacksTests.swift; sourceTree = "<group>"; };
+		AA3BD5591F2E6B1D007912C0 /* TweakButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakButtonTests.swift; sourceTree = "<group>"; };
 		B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakDebug.swift; sourceTree = "<group>"; };
 		D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakBindingIdentifier.swift; sourceTree = "<group>"; };
 		D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTweakBinding.swift; sourceTree = "<group>"; };
@@ -319,6 +321,7 @@
 				939F2CD11CB71AC900345E03 /* Tweak+TweaksTests.swift */,
 				930ECDB71DA6EEB9001009B3 /* TweakViewData+TweaksTests.swift */,
 				AA356AF31EB3C5B40063F4E2 /* TweakCallbacksTests.swift */,
+				AA3BD5591F2E6B1D007912C0 /* TweakButtonTests.swift */,
 				93A84EE21BEAE86E0022D2F3 /* Info.plist */,
 			);
 			path = SwiftTweaksTests;
@@ -564,6 +567,7 @@
 				939F2CCD1CB7196400345E03 /* AppTheme.swift in Sources */,
 				9314724F1BFFB41700F66D20 /* TweaksCollectionsListViewController.swift in Sources */,
 				931472541BFFB41700F66D20 /* TweakTableCell.swift in Sources */,
+				AA3BD55A1F2E6B1D007912C0 /* TweakButtonTests.swift in Sources */,
 				AA356AF61EB3C6550063F4E2 /* TweakButton.swift in Sources */,
 				93A84EF11BEAE88D0022D2F3 /* HashingUtilities.swift in Sources */,
 				931472581BFFB41700F66D20 /* TweakLibrary.swift in Sources */,

--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		93C942591BFBDC550054811A /* TweakBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C942581BFBDC550054811A /* TweakBinding.swift */; };
 		93DB80351BFCE4E80031D61A /* AnyTweak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DB80341BFCE4E80031D61A /* AnyTweak.swift */; };
 		93E777041BED4BBD003F0DE2 /* TweakLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E777031BED4BBD003F0DE2 /* TweakLibrary.swift */; };
+		AA19DB5320485D0B00C5538F /* StringOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932493981EFC5A4000B2E904 /* StringOptionViewController.swift */; };
 		AA356AF01EB3B5A90063F4E2 /* TweakCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AEF1EB3B5A90063F4E2 /* TweakCallbacks.swift */; };
 		AA356AF21EB3B7730063F4E2 /* TweakButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AF11EB3B7730063F4E2 /* TweakButton.swift */; };
 		AA356AF41EB3C5B40063F4E2 /* TweakCallbacksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AF31EB3C5B40063F4E2 /* TweakCallbacksTests.swift */; };
@@ -552,6 +553,7 @@
 				939F2CCF1CB7197800345E03 /* HitTransparentWindow.swift in Sources */,
 				931472511BFFB41700F66D20 /* TweakColorEditViewController.swift in Sources */,
 				931472611BFFB41700F66D20 /* Clip.swift in Sources */,
+				AA19DB5320485D0B00C5538F /* StringOptionViewController.swift in Sources */,
 				939F2CCE1CB7196800345E03 /* UIImage+SwiftTweaks.swift in Sources */,
 				9314725B1BFFB41700F66D20 /* TweakViewData.swift in Sources */,
 				9314724D1BFFB41700F66D20 /* TweaksViewController.swift in Sources */,

--- a/SwiftTweaks.xcodeproj/xcshareddata/xcschemes/SwiftTweaks.xcscheme
+++ b/SwiftTweaks.xcodeproj/xcshareddata/xcschemes/SwiftTweaks.xcscheme
@@ -27,7 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SwiftTweaks.xcodeproj/xcshareddata/xcschemes/SwiftTweaks.xcscheme
+++ b/SwiftTweaks.xcodeproj/xcshareddata/xcschemes/SwiftTweaks.xcscheme
@@ -27,7 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SwiftTweaks/FloatingTweakGroupViewController.swift
+++ b/SwiftTweaks/FloatingTweakGroupViewController.swift
@@ -303,7 +303,7 @@ extension FloatingTweakGroupViewController: UITableViewDelegate {
 			let alert = UIAlertController(title: "Can't edit string-options here.", message: "Sorry, haven't built out the floating UI for it yet!", preferredStyle: .alert)
 			alert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: nil))
 			present(alert, animated: true, completion: nil)
-		case .boolean, .integer, .cgFloat, .double, .action:
+		case .boolean, .integer, .cgFloat, .double, .closure:
 			break
 		}
 	}

--- a/SwiftTweaks/FloatingTweakGroupViewController.swift
+++ b/SwiftTweaks/FloatingTweakGroupViewController.swift
@@ -303,7 +303,7 @@ extension FloatingTweakGroupViewController: UITableViewDelegate {
 			let alert = UIAlertController(title: "Can't edit string-options here.", message: "Sorry, haven't built out the floating UI for it yet!", preferredStyle: .alert)
 			alert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: nil))
 			present(alert, animated: true, completion: nil)
-		case .boolean, .integer, .cgFloat, .double:
+		case .boolean, .integer, .cgFloat, .double, .action:
 			break
 		}
 	}

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -135,6 +135,10 @@ extension Tweak: TweakType {
 				defaultValue: defaultValue as! StringOption,
 				options: options!.map { $0 as! StringOption }
 			)
+		case .action:
+			return .action(
+				defaultValue: defaultValue as! TweakCallbacks
+			)
 		}
 	}
 

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -53,6 +53,15 @@ extension Tweak {
 			defaultValue: defaultValue
 		)
 	}
+	
+	public init(_ collectionName: String, _ groupName: String, _ tweakName: String, _ defaultValueProvider: () -> T) {
+		self.init(
+			collectionName: collectionName,
+			groupName: groupName,
+			tweakName: tweakName,
+			defaultValue: defaultValueProvider()
+		)
+	}
 
 }
 

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -135,8 +135,8 @@ extension Tweak: TweakType {
 				defaultValue: defaultValue as! StringOption,
 				options: options!.map { $0 as! StringOption }
 			)
-		case .action:
-			return .action(
+		case .closure:
+			return .closure(
 				defaultValue: defaultValue as! TweakCallbacks
 			)
 		}

--- a/SwiftTweaks/TweakBinding.swift
+++ b/SwiftTweaks/TweakBinding.swift
@@ -21,7 +21,7 @@ internal struct TweakBinding<T: TweakableType>: TweakBindingType{
 
 	func applyBindingWithValue(_ value: TweakableType) {
 		switch type(of: value).tweakViewDataType {
-		case .boolean, .integer, .cgFloat, .double, .uiColor, .stringList, .action:
+		case .boolean, .integer, .cgFloat, .double, .uiColor, .stringList, .closure:
 			binding(value as! T)
 		}
 	}

--- a/SwiftTweaks/TweakBinding.swift
+++ b/SwiftTweaks/TweakBinding.swift
@@ -21,7 +21,7 @@ internal struct TweakBinding<T: TweakableType>: TweakBindingType{
 
 	func applyBindingWithValue(_ value: TweakableType) {
 		switch type(of: value).tweakViewDataType {
-		case .boolean, .integer, .cgFloat, .double, .uiColor, .stringList:
+		case .boolean, .integer, .cgFloat, .double, .uiColor, .stringList, .action:
 			binding(value as! T)
 		}
 	}

--- a/SwiftTweaks/TweakButton.swift
+++ b/SwiftTweaks/TweakButton.swift
@@ -29,7 +29,7 @@ class TweakButton: UIButton {
 		didSet { updateState() }
 	}
 	
-	func setBorderColor(color: UIColor, for state: UIControlState = .normal) {
+	func setBorderColor(_ color: UIColor, for state: UIControlState = .normal) {
 		borderColors[state.rawValue] = color
 	}
 	

--- a/SwiftTweaks/TweakButton.swift
+++ b/SwiftTweaks/TweakButton.swift
@@ -22,11 +22,11 @@ final class TweakButton: UIButton {
 		didSet { updateState() }
 	}
 	
-	var borderWidth: CGFloat = 2 {
+	@objc var borderWidth: CGFloat = 2 {
 		didSet { updateState() }
 	}
 	
-	var cornerRadius: CGFloat = 4 {
+	@objc var cornerRadius: CGFloat = 4 {
 		didSet { updateState() }
 	}
 	

--- a/SwiftTweaks/TweakButton.swift
+++ b/SwiftTweaks/TweakButton.swift
@@ -8,11 +8,12 @@
 
 import UIKit
 
-class TweakButton: UIButton {
+final class TweakButton: UIButton {
 	
 	typealias ControlState = UInt
 	
-	private var borderColors: [ControlState: UIColor] = [:]
+	@objc private var borderColors: [ControlState: UIColor] = [:]
+	
 	override var isHighlighted: Bool {
 		didSet { updateState() }
 	}
@@ -31,12 +32,39 @@ class TweakButton: UIButton {
 	
 	func setBorderColor(_ color: UIColor, for state: UIControlState = .normal) {
 		borderColors[state.rawValue] = color
+		updateState()
 	}
 	
-	override func didMoveToWindow() {
-		super.didMoveToWindow()
+	func borderColor(for state: UIControlState) -> UIColor? {
+		return borderColors[state.rawValue]
+	}
+	
+	override init(frame: CGRect) {
+		super.init(frame: frame)
 		
 		updateState()
+	}
+	
+	required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+		
+		// NSCoder doesn't get CGFloats, and although is a Double _right now_, we could use a little trick to avoid casing
+		borderWidth = aDecoder.decodeCGVector(forKey: #keyPath(borderWidth)).dx
+		cornerRadius = aDecoder.decodeCGVector(forKey: #keyPath(cornerRadius)).dx
+		
+		if let colorsString = aDecoder.decodeObject(forKey: #keyPath(borderColors)) as? String {
+			borderColors = type(of: self).decodeBorderColors(from: colorsString)
+		}
+		
+		updateState()
+	}
+	
+	override func encode(with aCoder: NSCoder) {
+		super.encode(with: aCoder)
+		
+		aCoder.encode(CGVector(dx: borderWidth, dy: 0), forKey: #keyPath(borderWidth))
+		aCoder.encode(CGVector(dx: cornerRadius, dy: 0), forKey: #keyPath(cornerRadius))
+		aCoder.encode(type(of: self).encodeBorderColors(from: borderColors), forKey: #keyPath(borderColors))
 	}
 	
 	// MARK: - Private
@@ -55,5 +83,28 @@ class TweakButton: UIButton {
 		size.height += borderWidth * 2
 		
 		return size
+	}
+	
+	private static func encodeBorderColors(from colors: [ControlState: UIColor]) -> String {
+		var encodedString = ""
+		for (state, color) in colors {
+			encodedString += "\(state):\(color.hexString)|"
+		}
+		return encodedString
+	}
+	
+	private static func decodeBorderColors(from string: String) -> [ControlState: UIColor] {
+		var colors: [ControlState: UIColor] = [:]
+		let pairs = string.components(separatedBy: "|")
+		pairs.forEach {
+			let pair = $0.components(separatedBy: ":")
+			guard pair.count == 2,
+				let state = ControlState(pair[0]),
+				let color = UIColor.colorWithHexString(pair[1]) else{
+				return
+			}
+			colors[state] = color
+		}
+		return colors
 	}
 }

--- a/SwiftTweaks/TweakButton.swift
+++ b/SwiftTweaks/TweakButton.swift
@@ -1,0 +1,59 @@
+//
+//  TweakButton.swift
+//  SwiftTweaks
+//
+//  Created by Jarosław Pendowski on 28/04/2017.
+//  Copyright © 2017 Khan Academy. All rights reserved.
+//
+
+import UIKit
+
+class TweakButton: UIButton {
+	
+	typealias ControlState = UInt
+	
+	private var borderColors: [ControlState: UIColor] = [:]
+	override var isHighlighted: Bool {
+		didSet { updateState() }
+	}
+	
+	override var isEnabled: Bool {
+		didSet { updateState() }
+	}
+	
+	var borderWidth: CGFloat = 2 {
+		didSet { updateState() }
+	}
+	
+	var cornerRadius: CGFloat = 4 {
+		didSet { updateState() }
+	}
+	
+	func setBorderColor(color: UIColor, for state: UIControlState = .normal) {
+		borderColors[state.rawValue] = color
+	}
+	
+	override func didMoveToWindow() {
+		super.didMoveToWindow()
+		
+		updateState()
+	}
+	
+	// MARK: - Private
+	
+	private func updateState() {
+		let color = borderColors[state.rawValue]
+		layer.borderColor = color?.cgColor
+		layer.borderWidth = borderWidth
+		layer.cornerRadius = cornerRadius
+	}
+	
+	override func sizeThatFits(_ size: CGSize) -> CGSize {
+		var size = super.sizeThatFits(size)
+		
+		size.width += borderWidth * 2
+		size.height += borderWidth * 2
+		
+		return size
+	}
+}

--- a/SwiftTweaks/TweakCallbacks.swift
+++ b/SwiftTweaks/TweakCallbacks.swift
@@ -1,0 +1,56 @@
+//
+//  TweakCallbacks.swift
+//  SwiftTweaks
+//
+//  Created by Jarosław Pendowski on 28/04/2017.
+//  Copyright © 2017 Khan Academy. All rights reserved.
+//
+
+import Foundation
+
+public typealias TweakBlock = () -> Void
+
+public class TweakCallbacks {
+	public typealias CallbackIdentifier = String
+	
+	private var callbacks: [CallbackIdentifier: TweakBlock] = [:]
+	
+	public init() {}
+	
+	public func addCallback(_ callback: @escaping TweakBlock) -> CallbackIdentifier {
+		let token = UUID().uuidString
+		callbacks[token] = callback
+		return token
+	}
+	
+	public func removeCallback(with token: CallbackIdentifier) {
+		callbacks[token] = nil
+	}
+	
+	// MARK: Internal
+	
+	func executeAllCallbacks() {
+		callbacks.forEach { $0.value() }
+	}
+}
+
+extension TweakCallbacks: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .action
+	}
+}
+
+extension Tweak where T == TweakCallbacks {
+	
+	public init(_ collectionName: String, _ groupName: String, _ tweakName: String) {
+		self.init(collectionName, groupName, tweakName, TweakCallbacks())
+	}
+	
+	public func addCallback(_ callback: @escaping TweakBlock) -> TweakCallbacks.CallbackIdentifier {
+		return defaultValue.addCallback(callback)
+	}
+	
+	public func removeCallback(with token: TweakCallbacks.CallbackIdentifier) {
+		defaultValue.removeCallback(with: token)
+	}
+}

--- a/SwiftTweaks/TweakCallbacks.swift
+++ b/SwiftTweaks/TweakCallbacks.swift
@@ -11,16 +11,18 @@ import Foundation
 public typealias TweakBlock = () -> Void
 
 public class TweakCallbacks {
-	public typealias CallbackIdentifier = String
+	public typealias CallbackIdentifier = UInt
 	
+	private var lastToken: CallbackIdentifier = 0
 	private var callbacks: [CallbackIdentifier: TweakBlock] = [:]
 	
 	public init() {}
 	
 	public func addCallback(_ callback: @escaping TweakBlock) -> CallbackIdentifier {
-		let token = UUID().uuidString
-		callbacks[token] = callback
-		return token
+		let nextToken = lastToken + 1
+		callbacks[nextToken] = callback
+		lastToken = nextToken
+		return nextToken
 	}
 	
 	public func removeCallback(with token: CallbackIdentifier) {
@@ -30,7 +32,7 @@ public class TweakCallbacks {
 	// MARK: Internal
 	
 	func executeAllCallbacks() {
-		callbacks.forEach { $0.value() }
+		callbacks.keys.sorted().forEach { callbacks[$0]?() }
 	}
 }
 

--- a/SwiftTweaks/TweakCallbacks.swift
+++ b/SwiftTweaks/TweakCallbacks.swift
@@ -11,6 +11,10 @@ import Foundation
 public typealias TweakBlock = () -> Void
 
 public class TweakCallbacks {
+	public enum Error: Swift.Error {
+		case wrongIdentifier
+	}
+	
 	public typealias CallbackIdentifier = UInt
 	
 	private var lastToken: CallbackIdentifier = 0
@@ -25,7 +29,10 @@ public class TweakCallbacks {
 		return nextToken
 	}
 	
-	public func removeCallback(with token: CallbackIdentifier) {
+	public func removeCallback(with token: CallbackIdentifier) throws {
+		guard callbacks.keys.contains(token) else {
+			throw Error.wrongIdentifier
+		}
 		callbacks[token] = nil
 	}
 	
@@ -53,7 +60,7 @@ extension Tweak where T == TweakCallbacks {
 		return defaultValue.addCallback(callback)
 	}
 	
-	public func removeCallback(with token: TweakCallbacks.CallbackIdentifier) {
-		defaultValue.removeCallback(with: token)
+	public func removeCallback(with token: TweakCallbacks.CallbackIdentifier) throws {
+		try defaultValue.removeCallback(with: token)
 	}
 }

--- a/SwiftTweaks/TweakCallbacks.swift
+++ b/SwiftTweaks/TweakCallbacks.swift
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import UIKit
 
-public typealias TweakBlock = () -> Void
+public typealias TweakBlock = (_ sender: UIView, _ viewController: UIViewController?) -> Void
 
 public class TweakCallbacks {
 	public enum Error: Swift.Error {
@@ -38,8 +39,8 @@ public class TweakCallbacks {
 	
 	// MARK: Internal
 	
-	func executeAllCallbacks() {
-		callbacks.keys.sorted().forEach { callbacks[$0]?() }
+	func executeAllCallbacks(sender: UIView, viewController: UIViewController?) {
+		callbacks.keys.sorted().forEach { callbacks[$0]?(sender, viewController) }
 	}
 }
 

--- a/SwiftTweaks/TweakCallbacks.swift
+++ b/SwiftTweaks/TweakCallbacks.swift
@@ -48,6 +48,7 @@ extension Tweak where T == TweakCallbacks {
 		self.init(collectionName, groupName, tweakName, TweakCallbacks())
 	}
 	
+	@discardableResult
 	public func addCallback(_ callback: @escaping TweakBlock) -> TweakCallbacks.CallbackIdentifier {
 		return defaultValue.addCallback(callback)
 	}

--- a/SwiftTweaks/TweakCallbacks.swift
+++ b/SwiftTweaks/TweakCallbacks.swift
@@ -45,7 +45,7 @@ public class TweakCallbacks {
 
 extension TweakCallbacks: TweakableType {
 	public static var tweakViewDataType: TweakViewDataType {
-		return .action
+		return .closure
 	}
 }
 

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -164,6 +164,7 @@ extension TweakCollectionViewController: UITableViewDataSource {
 		cell.textLabel?.text = tweak.tweakName
 		cell.viewData = tweakStore.currentViewDataForTweak(tweak)
 		cell.delegate = self
+		cell.ownerViewController = self
 		return cell
 	}
 

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -125,7 +125,7 @@ extension TweakCollectionViewController: UITableViewDelegate {
 		case .stringList:
 			let stringOptionVC = StringOptionViewController(anyTweak: tweak, tweakStore: self.tweakStore, delegate: self)
 			self.navigationController?.pushViewController(stringOptionVC, animated: true)
-		case .boolean, .integer, .cgFloat, .double, .action:
+		case .boolean, .integer, .cgFloat, .double, .closure:
 			break
 		}
 	}

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -125,7 +125,7 @@ extension TweakCollectionViewController: UITableViewDelegate {
 		case .stringList:
 			let stringOptionVC = StringOptionViewController(anyTweak: tweak, tweakStore: self.tweakStore, delegate: self)
 			self.navigationController?.pushViewController(stringOptionVC, animated: true)
-		case .boolean, .integer, .cgFloat, .double:
+		case .boolean, .integer, .cgFloat, .double, .action:
 			break
 		}
 	}

--- a/SwiftTweaks/TweakLibrary.swift
+++ b/SwiftTweaks/TweakLibrary.swift
@@ -40,4 +40,8 @@ public extension TweakLibraryType {
 	static func unbindMultiple(identifier: MultiTweakBindingIdentifier) {
 		self.defaultStore.unbindMultiple(identifier)
 	}
+	
+	static func overrideValue<T>(_ tweak: Tweak<T>, value: T?) {
+		self.defaultStore.setValue(value, forTweak: tweak)
+	}
 }

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -177,7 +177,7 @@ private final class TweakDiskPersistency {
 					return nil
 				}
 				return StringOption(value: stringOptionString)
-			case .action: return nil
+			case .closure: return nil
 			}
 		}
 	}
@@ -193,7 +193,7 @@ private extension TweakViewDataType {
 		case .double: return "double"
 		case .uiColor: return "uicolor"
 		case .stringList: return "stringlist"
-		case .action: return "action"
+		case .closure: return "closure"
 		}
 	}
 }
@@ -208,7 +208,7 @@ private extension TweakableType {
 			case .double: return self as! Double as AnyObject
 			case .uiColor: return self as! UIColor
 			case .stringList: return (self as! StringOption).value as AnyObject
-			case .action: return true as AnyObject
+			case .closure: return true as AnyObject
 		}
 	}
 }

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -177,6 +177,7 @@ private final class TweakDiskPersistency {
 					return nil
 				}
 				return StringOption(value: stringOptionString)
+			case .action: return nil
 			}
 		}
 	}
@@ -192,6 +193,7 @@ private extension TweakViewDataType {
 		case .double: return "double"
 		case .uiColor: return "uicolor"
 		case .stringList: return "stringlist"
+		case .action: return "action"
 		}
 	}
 }
@@ -206,6 +208,7 @@ private extension TweakableType {
 			case .double: return self as! Double as AnyObject
 			case .uiColor: return self as! UIColor
 			case .stringList: return (self as! StringOption).value as AnyObject
+			case .action: return true as AnyObject
 		}
 	}
 }

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -156,9 +156,9 @@ public final class TweakStore {
 		case let .stringList(defaultValue: defaultValue, options: options):
 			let currentValue = cachedValue as? StringOption ?? defaultValue
 			return .stringList(value: currentValue, defaultValue: defaultValue, options: options)
-		case let .action(defaultValue: defaultValue):
+		case let .closure(defaultValue: defaultValue):
 			let currentValue = cachedValue as? TweakCallbacks ?? defaultValue
-			return .action(value: currentValue)
+			return .closure(value: currentValue)
 		}
 	}
 

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -156,6 +156,9 @@ public final class TweakStore {
 		case let .stringList(defaultValue: defaultValue, options: options):
 			let currentValue = cachedValue as? StringOption ?? defaultValue
 			return .stringList(value: currentValue, defaultValue: defaultValue, options: options)
+		case let .action(defaultValue: defaultValue):
+			let currentValue = cachedValue as? TweakCallbacks ?? defaultValue
+			return .action(value: currentValue)
 		}
 	}
 

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -161,6 +161,12 @@ public final class TweakStore {
 			return .closure(value: currentValue)
 		}
 	}
+	
+	internal func setValue<T>(_ value: T?, forTweak tweak: Tweak<T>) {
+		let anyTweak = AnyTweak(tweak: tweak)
+		persistence.setValue(value, forTweakIdentifiable: anyTweak)
+		updateBindingsForTweak(anyTweak)
+	}
 
 	internal func setValue(_ viewData: TweakViewData, forTweak tweak: AnyTweak) {
 		persistence.setValue(viewData.value, forTweakIdentifiable: tweak)

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -70,10 +70,11 @@ internal final class TweakTableCell: UITableViewCell {
 	}()
 	private let actionButton: TweakButton = {
 		let button = TweakButton(type: .system)
-		button.setTitle("🤖", for: .normal)
 		button.borderWidth = 2
-		button.setBorderColor(color: AppTheme.Colors.controlTinted, for: .normal)
-		button.setBorderColor(color: AppTheme.Colors.controlTintedPressed, for: .highlighted)
+		button.contentMode = .center
+		button.setImage(UIImage(swiftTweaksImage: .disclosureIndicator), for: .normal)
+		button.setBorderColor(AppTheme.Colors.controlTinted, for: .normal)
+		button.setBorderColor(AppTheme.Colors.controlTintedPressed, for: .highlighted)
 		return button
 	}()
 
@@ -185,10 +186,10 @@ internal final class TweakTableCell: UITableViewCell {
 			accessory.bounds = textField.bounds
 
 		case .action:
-			actionButton.sizeToFit()
-			actionButton.bounds.size.width = 64
+			actionButton.bounds.size = CGSize(width: 64, height: 32)
 			var frame = actionButton.bounds
-			frame.origin.x = -1 * actionButton.bounds.width / 2
+			frame.origin.x = -1 * frame.width / 2
+			frame.origin.y = -1 * frame.height / 2
 			accessory.bounds = frame
 		}
 	}

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -68,9 +68,12 @@ internal final class TweakTableCell: UITableViewCell {
 		imageView.tintColor = AppTheme.Colors.controlSecondary
 		return imageView
 	}()
-	private let actionButton: UIButton = {
-		let button = UIButton(type: .system)
+	private let actionButton: TweakButton = {
+		let button = TweakButton(type: .system)
 		button.setTitle("🤖", for: .normal)
+		button.borderWidth = 2
+		button.setBorderColor(color: AppTheme.Colors.controlTinted, for: .normal)
+		button.setBorderColor(color: AppTheme.Colors.controlTintedPressed, for: .highlighted)
 		return button
 	}()
 
@@ -183,7 +186,10 @@ internal final class TweakTableCell: UITableViewCell {
 
 		case .action:
 			actionButton.sizeToFit()
-			accessory.bounds = actionButton.bounds
+			actionButton.bounds.size.width = 64
+			var frame = actionButton.bounds
+			frame.origin.x = -1 * actionButton.bounds.width / 2
+			accessory.bounds = frame
 		}
 	}
 

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -185,7 +185,7 @@ internal final class TweakTableCell: UITableViewCell {
 			textField.frame = textFieldFrame
 			accessory.bounds = textField.bounds
 
-		case .action:
+		case .closure:
 			actionButton.bounds.size = CGSize(width: 64, height: 32)
 			var frame = actionButton.bounds
 			frame.origin.x = -1 * frame.width / 2
@@ -235,7 +235,7 @@ internal final class TweakTableCell: UITableViewCell {
 			colorChit.isHidden = true
 			disclosureArrow.isHidden = true
 			actionButton.isHidden = true
-		case .action:
+		case .closure:
 			switchControl.isHidden = true
 			textField.isHidden = true
 			stepperControl.isHidden = true
@@ -275,7 +275,7 @@ internal final class TweakTableCell: UITableViewCell {
 		case let .stringList(value: value, _, options: _):
 			textField.text = value.value
 			textFieldEnabled = false
-		case .action:
+		case .closure:
 			textFieldEnabled = false
 		}
 
@@ -316,7 +316,7 @@ internal final class TweakTableCell: UITableViewCell {
 		case let .doubleTweak(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			viewData = TweakViewData(type: .double, value: stepperControl.value, defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
 			delegate?.tweakCellDidChangeCurrentValue(self)
-		case .color, .boolean, .stringList, .action:
+		case .color, .boolean, .stringList, .closure:
 			assertionFailure("Shouldn't be able to update text field with a Color or Boolean or StringList tweak.")
 		}
 	}
@@ -327,7 +327,7 @@ internal final class TweakTableCell: UITableViewCell {
 		}
 		
 		switch viewData {
-		case let .action(closureTweak):
+		case let .closure(closureTweak):
 			closureTweak.executeAllCallbacks()
 		default:
 			assertionFailure("Shouldn't be able to update text field with a Color or Boolean or StringList tweak.")
@@ -375,7 +375,7 @@ extension TweakTableCell: UITextFieldDelegate {
 			} else {
 				updateSubviews()
 			}
-		case .boolean, .stringList, .action:
+		case .boolean, .stringList, .closure:
 			assertionFailure("Shouldn't be able to update text field with a Boolean or StringList tweak.")
 		}
 	}

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -77,6 +77,8 @@ internal final class TweakTableCell: UITableViewCell {
 		button.setBorderColor(AppTheme.Colors.controlTintedPressed, for: .highlighted)
 		return button
 	}()
+	
+	weak var ownerViewController: UIViewController?
 
 	override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
 		super.init(style: .value1, reuseIdentifier: reuseIdentifier)
@@ -328,7 +330,7 @@ internal final class TweakTableCell: UITableViewCell {
 		
 		switch viewData {
 		case let .closure(closureTweak):
-			closureTweak.executeAllCallbacks()
+			closureTweak.executeAllCallbacks(sender: sender, viewController: ownerViewController)
 		default:
 			assertionFailure("Shouldn't be able to update text field with a Color or Boolean or StringList tweak.")
 		}

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -16,6 +16,7 @@ internal enum TweakViewData {
 	case doubleTweak(value: Double, defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(value: UIColor, defaultValue: UIColor)
 	case stringList(value: StringOption, defaultValue: StringOption, options: [StringOption])
+	case action(value: TweakCallbacks)
 
 	init<T: TweakableType>(type: TweakViewDataType, value: T, defaultValue: T, minimum: T?, maximum: T?, stepSize: T?, options: [T]?) {
 		switch type {
@@ -34,6 +35,8 @@ internal enum TweakViewData {
 			self = .doubleTweak(value: clippedValue, defaultValue: defaultValue as! Double, min: minimum as? Double, max: maximum as? Double, stepSize: stepSize as? Double)
 		case .stringList:
 			self = .stringList(value: value as! StringOption, defaultValue: defaultValue as! StringOption, options: options!.map { $0 as! StringOption })
+		case .action:
+			self = .action(value: value as! TweakCallbacks)
 		}
 	}
 
@@ -51,13 +54,15 @@ internal enum TweakViewData {
 			return colorValue
 		case let .stringList(value: stringValue, _, _):
 			return stringValue
+		case let .action(value: value):
+			return value
 		}
 	}
 
 	/// For signedNumberType tweaks, this is a shortcut to `value` as a Double
 	var doubleValue: Double? {
 		switch self {
-		case .boolean, .color, .stringList:
+		case .boolean, .color, .stringList, .action:
 			return nil
 		case let .integer(value: intValue, _, _, _, _):
 			return Double(intValue)
@@ -90,6 +95,9 @@ internal enum TweakViewData {
 		case let .stringList(value: value, defaultValue: defaultValue, _):
 			string = value.value
 			differsFromDefault = string != defaultValue.value
+		case .action:
+			string = ""
+			differsFromDefault = false
 		}
 		return (string, differsFromDefault)
 	}
@@ -98,7 +106,7 @@ internal enum TweakViewData {
 		switch self {
 		case .integer, .float, .doubleTweak:
 			return true
-		case .boolean, .color, .stringList:
+		case .boolean, .color, .stringList, .action:
 			return false
 		}
 	}
@@ -138,7 +146,7 @@ internal enum TweakViewData {
 		let step: Double?
 		let isInteger: Bool
 		switch self {
-		case .boolean, .color, .stringList:
+		case .boolean, .color, .stringList, .action:
 			return nil
 
 		case let .integer(intValue, intDefaultValue, intMin, intMax, intStep):

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -16,7 +16,7 @@ internal enum TweakViewData {
 	case doubleTweak(value: Double, defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(value: UIColor, defaultValue: UIColor)
 	case stringList(value: StringOption, defaultValue: StringOption, options: [StringOption])
-	case action(value: TweakCallbacks)
+	case closure(value: TweakCallbacks)
 
 	init<T: TweakableType>(type: TweakViewDataType, value: T, defaultValue: T, minimum: T?, maximum: T?, stepSize: T?, options: [T]?) {
 		switch type {
@@ -35,8 +35,8 @@ internal enum TweakViewData {
 			self = .doubleTweak(value: clippedValue, defaultValue: defaultValue as! Double, min: minimum as? Double, max: maximum as? Double, stepSize: stepSize as? Double)
 		case .stringList:
 			self = .stringList(value: value as! StringOption, defaultValue: defaultValue as! StringOption, options: options!.map { $0 as! StringOption })
-		case .action:
-			self = .action(value: value as! TweakCallbacks)
+		case .closure:
+			self = .closure(value: value as! TweakCallbacks)
 		}
 	}
 
@@ -54,7 +54,7 @@ internal enum TweakViewData {
 			return colorValue
 		case let .stringList(value: stringValue, _, _):
 			return stringValue
-		case let .action(value: value):
+		case let .closure(value: value):
 			return value
 		}
 	}
@@ -62,7 +62,7 @@ internal enum TweakViewData {
 	/// For signedNumberType tweaks, this is a shortcut to `value` as a Double
 	var doubleValue: Double? {
 		switch self {
-		case .boolean, .color, .stringList, .action:
+		case .boolean, .color, .stringList, .closure:
 			return nil
 		case let .integer(value: intValue, _, _, _, _):
 			return Double(intValue)
@@ -95,7 +95,7 @@ internal enum TweakViewData {
 		case let .stringList(value: value, defaultValue: defaultValue, _):
 			string = value.value
 			differsFromDefault = string != defaultValue.value
-		case .action:
+		case .closure:
 			string = ""
 			differsFromDefault = false
 		}
@@ -106,7 +106,7 @@ internal enum TweakViewData {
 		switch self {
 		case .integer, .float, .doubleTweak:
 			return true
-		case .boolean, .color, .stringList, .action:
+		case .boolean, .color, .stringList, .closure:
 			return false
 		}
 	}
@@ -146,7 +146,7 @@ internal enum TweakViewData {
 		let step: Double?
 		let isInteger: Bool
 		switch self {
-		case .boolean, .color, .stringList, .action:
+		case .boolean, .color, .stringList, .closure:
 			return nil
 
 		case let .integer(intValue, intDefaultValue, intMin, intMax, intStep):

--- a/SwiftTweaks/TweakableType.swift
+++ b/SwiftTweaks/TweakableType.swift
@@ -16,7 +16,7 @@ public protocol TweakableType {
 }
 
 /// The data types that are currently supported for SwiftTweaks.
-/// While Tweak<T> is generic, we have to build UI for editing each kind of <T> - hence the need for a protocol to restrict what can be tweaked.
+/// While Tweak<T> is generic, we have to build UI for editing each kind of <T> - hence the need for a protocol to restrict what cavare tweaked.
 /// Of course, we can add new TweakViewDataTypes over time, too!
 public enum TweakViewDataType {
 	case boolean
@@ -25,9 +25,10 @@ public enum TweakViewDataType {
 	case double
 	case uiColor
 	case stringList
+	case action
 
 	public static let allTypes: [TweakViewDataType] = [
-		.boolean, .integer, .cgFloat, .double, .uiColor, .stringList
+		.boolean, .integer, .cgFloat, .double, .uiColor, .stringList, .action
 	]
 }
 
@@ -41,6 +42,7 @@ public enum TweakDefaultData {
 	case doubleTweak(defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(defaultValue: UIColor)
 	case stringList(defaultValue: StringOption, options: [StringOption])
+	case action(defaultValue: TweakCallbacks)
 }
 
 // MARK: Types that conform to TweakableType
@@ -94,4 +96,3 @@ extension UIColor: TweakableType {
 		return .uiColor
 	}
 }
-

--- a/SwiftTweaks/TweakableType.swift
+++ b/SwiftTweaks/TweakableType.swift
@@ -25,10 +25,10 @@ public enum TweakViewDataType {
 	case double
 	case uiColor
 	case stringList
-	case action
+	case closure
 
 	public static let allTypes: [TweakViewDataType] = [
-		.boolean, .integer, .cgFloat, .double, .uiColor, .stringList, .action
+		.boolean, .integer, .cgFloat, .double, .uiColor, .stringList, .closure
 	]
 }
 
@@ -42,7 +42,7 @@ public enum TweakDefaultData {
 	case doubleTweak(defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(defaultValue: UIColor)
 	case stringList(defaultValue: StringOption, options: [StringOption])
-	case action(defaultValue: TweakCallbacks)
+	case closure(defaultValue: TweakCallbacks)
 }
 
 // MARK: Types that conform to TweakableType

--- a/SwiftTweaksTests/TweakButtonTests.swift
+++ b/SwiftTweaksTests/TweakButtonTests.swift
@@ -1,0 +1,36 @@
+//
+//  TweakButtonTests.swift
+//  SwiftTweaks
+//
+//  Created by Jarosław Pendowski on 30/07/2017.
+//  Copyright © 2017 Khan Academy. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftTweaks
+
+class TweakButtonTests: XCTestCase {
+    
+    func testNSCoder() {
+        let originalButton = TweakButton(frame: .zero)
+		originalButton.borderWidth = 3
+		originalButton.cornerRadius = 5
+		
+		originalButton.setBorderColor(.orange, for: .normal)
+		originalButton.setBorderColor(.green, for: .highlighted)
+		
+		let codedData = NSKeyedArchiver.archivedData(withRootObject: originalButton)
+		
+		guard let decodedButton = NSKeyedUnarchiver.unarchiveObject(with: codedData) as? TweakButton else {
+			XCTFail()
+			return
+		}
+		
+		XCTAssertEqual(originalButton.borderWidth, decodedButton.borderWidth)
+		XCTAssertEqual(originalButton.cornerRadius, decodedButton.cornerRadius)
+		XCTAssertEqual(originalButton.borderColor(for: .normal)?.hexString, decodedButton.borderColor(for: .normal)?.hexString)			// has to be string, since it doesn't work well with floating points
+		XCTAssertEqual(originalButton.borderColor(for: .highlighted)?.hexString, decodedButton.borderColor(for: .highlighted)?.hexString) // has to be string, since it doesn't work well with floating points
+	}
+    
+	
+}

--- a/SwiftTweaksTests/TweakCallbacksTests.swift
+++ b/SwiftTweaksTests/TweakCallbacksTests.swift
@@ -32,7 +32,7 @@ class TweakCallbacksTests: XCTestCase {
 	
 	func testAddingCallback() {
 		var executed = false
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			executed = true
 		}
 		// shouldn't be executed after just adding
@@ -46,13 +46,13 @@ class TweakCallbacksTests: XCTestCase {
 	func testOrder() {
 		var order: [Int] = []
 		
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			order.append(0)
 		}
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			order.append(1)
 		}
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			order.append(2)
 		}
 		
@@ -66,13 +66,13 @@ class TweakCallbacksTests: XCTestCase {
 	func testMultipleExecutions() {
 		var order: [Int] = []
 		
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			order.append(0)
 		}
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			order.append(1)
 		}
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			order.append(2)
 		}
 		
@@ -94,13 +94,13 @@ class TweakCallbacksTests: XCTestCase {
 	func testRemovingCallback() {
 		var order: [Int] = []
 		
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			order.append(0)
 		}
-		let identifier = tweak.addCallback {
+		let identifier = tweak.addCallback { _,_ in
 			order.append(1)
 		}
-		tweak.addCallback {
+		tweak.addCallback { _,_ in
 			order.append(2)
 		}
 		
@@ -125,6 +125,6 @@ class TweakCallbacksTests: XCTestCase {
 	}
 	
 	private func executeTweak() {
-		tweak.defaultValue.executeAllCallbacks()
+		tweak.defaultValue.executeAllCallbacks(sender: UIView(), viewController: nil)
 	}
 }

--- a/SwiftTweaksTests/TweakCallbacksTests.swift
+++ b/SwiftTweaksTests/TweakCallbacksTests.swift
@@ -1,0 +1,130 @@
+//
+//  TweakCallbacksTests.swift
+//  SwiftTweaks
+//
+//  Created by Jarosław Pendowski on 28/04/2017.
+//  Copyright © 2017 Khan Academy. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftTweaks
+
+class TweakCallbacksTests: XCTestCase {
+	
+	var tweak: Tweak<TweakCallbacks>!
+    
+    override func setUp() {
+        super.setUp()
+		
+		tweak = Tweak<TweakCallbacks>("", "", "")
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+		
+		tweak = nil
+    }
+	
+	func testEmpty() {
+		// should just not crash
+		executeTweak()
+	}
+	
+	func testAddingCallback() {
+		var executed = false
+		tweak.addCallback {
+			executed = true
+		}
+		// shouldn't be executed after just adding
+		XCTAssertFalse(executed)
+		
+		executeTweak()
+		
+		XCTAssertTrue(executed)
+	}
+	
+	func testOrder() {
+		var order: [Int] = []
+		
+		tweak.addCallback {
+			order.append(0)
+		}
+		tweak.addCallback {
+			order.append(1)
+		}
+		tweak.addCallback {
+			order.append(2)
+		}
+		
+		XCTAssertEqual(order, [])
+		
+		executeTweak()
+		
+		XCTAssertEqual(order, [0, 1, 2])
+	}
+	
+	func testMultipleExecutions() {
+		var order: [Int] = []
+		
+		tweak.addCallback {
+			order.append(0)
+		}
+		tweak.addCallback {
+			order.append(1)
+		}
+		tweak.addCallback {
+			order.append(2)
+		}
+		
+		XCTAssertEqual(order, [])
+		
+		executeTweak()
+		
+		XCTAssertEqual(order, [0, 1, 2])
+		
+		executeTweak()
+		
+		XCTAssertEqual(order, [0, 1, 2, 0, 1, 2])
+		
+		executeTweak()
+		
+		XCTAssertEqual(order, [0, 1, 2, 0, 1, 2, 0, 1, 2])
+	}
+	
+	func testRemovingCallback() {
+		var order: [Int] = []
+		
+		tweak.addCallback {
+			order.append(0)
+		}
+		let identifier = tweak.addCallback {
+			order.append(1)
+		}
+		tweak.addCallback {
+			order.append(2)
+		}
+		
+		XCTAssertEqual(order, [])
+		
+		executeTweak()
+		
+		XCTAssertEqual(order, [0, 1, 2])
+		
+		_ = try? tweak.removeCallback(with: identifier)
+		
+		executeTweak()
+
+		XCTAssertEqual(order, [0, 1, 2, 0, 2])
+	}
+	
+	func testRemovingNonExisting() {
+		do {
+			try tweak.removeCallback(with: 42)
+			XCTFail("Should threw at nonexisting identifier")
+		} catch { }
+	}
+	
+	private func executeTweak() {
+		tweak.defaultValue.executeAllCallbacks()
+	}
+}

--- a/iOS Example/iOS Example.xcodeproj/project.pbxproj
+++ b/iOS Example/iOS Example.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		93A3AF281BF143B400CAD43B /* SwiftTweaks.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 93A3AF241BF143AC00CAD43B /* SwiftTweaks.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		93A3AF2E1BF1443A00CAD43B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93A3AF2C1BF1443A00CAD43B /* LaunchScreen.storyboard */; };
 		93A3AF301BF154D600CAD43B /* ExampleTweaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A3AF2F1BF154D600CAD43B /* ExampleTweaks.swift */; };
+		AA48CC35202C8BA700C178DA /* ExampleCallbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA48CC34202C8BA700C178DA /* ExampleCallbackViewController.swift */; };
+		AA48CC38202C8F2900C178DA /* ExampleCallbackViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA48CC37202C8F2900C178DA /* ExampleCallbackViewController.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +65,8 @@
 		93A3AF1E1BF143AC00CAD43B /* SwiftTweaks.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftTweaks.xcodeproj; path = ../SwiftTweaks.xcodeproj; sourceTree = "<group>"; };
 		93A3AF2D1BF1443A00CAD43B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		93A3AF2F1BF154D600CAD43B /* ExampleTweaks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleTweaks.swift; sourceTree = "<group>"; };
+		AA48CC34202C8BA700C178DA /* ExampleCallbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleCallbackViewController.swift; sourceTree = "<group>"; };
+		AA48CC37202C8F2900C178DA /* ExampleCallbackViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ExampleCallbackViewController.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +104,8 @@
 				93A3AEFE1BF142A400CAD43B /* AppDelegate.swift */,
 				93A3AF2F1BF154D600CAD43B /* ExampleTweaks.swift */,
 				93A3AF001BF142A400CAD43B /* ViewController.swift */,
+				AA48CC34202C8BA700C178DA /* ExampleCallbackViewController.swift */,
+				AA48CC37202C8F2900C178DA /* ExampleCallbackViewController.xib */,
 				93A3AF051BF142A400CAD43B /* Assets.xcassets */,
 				93A3AF2C1BF1443A00CAD43B /* LaunchScreen.storyboard */,
 				93A3AF0A1BF142A400CAD43B /* Info.plist */,
@@ -201,6 +207,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				93A3AF061BF142A400CAD43B /* Assets.xcassets in Resources */,
+				AA48CC38202C8F2900C178DA /* ExampleCallbackViewController.xib in Resources */,
 				93A3AF2E1BF1443A00CAD43B /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -214,6 +221,7 @@
 			files = (
 				93A3AF011BF142A400CAD43B /* ViewController.swift in Sources */,
 				93A3AF301BF154D600CAD43B /* ExampleTweaks.swift in Sources */,
+				AA48CC35202C8BA700C178DA /* ExampleCallbackViewController.swift in Sources */,
 				93A3AEFF1BF142A400CAD43B /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS Example/iOS Example/ExampleCallbackViewController.swift
+++ b/iOS Example/iOS Example/ExampleCallbackViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ExampleCallbackViewController.swift
+//  iOS Example
+//
+//  Created by Jarek Pendowski on 08/02/2018.
+//  Copyright © 2018 Khan Academy. All rights reserved.
+//
+
+import UIKit
+
+class ExampleCallbackViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+}

--- a/iOS Example/iOS Example/ExampleCallbackViewController.xib
+++ b/iOS Example/iOS Example/ExampleCallbackViewController.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ExampleCallbackViewController" customModule="iOS_Example" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="0bU-yZ-fxe"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Here you can provide custom UI for whatever you need. Hidden inside Tweaks." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kLp-w1-F2E">
+                    <rect key="frame" x="16" y="323.5" width="343" height="20.5"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="kLp-w1-F2E" secondAttribute="trailing" constant="16" id="8T9-Xr-0qM"/>
+                <constraint firstItem="kLp-w1-F2E" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="EVF-nD-mcO"/>
+                <constraint firstItem="kLp-w1-F2E" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Ik0-jb-KXH"/>
+                <constraint firstItem="kLp-w1-F2E" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="dpd-o7-cbg"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>

--- a/iOS Example/iOS Example/ExampleTweaks.swift
+++ b/iOS Example/iOS Example/ExampleTweaks.swift
@@ -32,8 +32,8 @@ public struct ExampleTweaks: TweakLibraryType {
 	// Tweaks are often used in combination with each other, so we have some templates available for ease-of-use:
 	public static let buttonAnimation = SpringAnimationTweakTemplate("Animation", "Button Animation", duration: 0.5) // Note: "duration" is optional, if you don't provide it, there's a sensible default!
 
-    public static let actionUI = Tweak<TweakCallbacks>("Action", "UI", "Dismiss and show alert")
-    public static let actionConsole = Tweak<TweakCallbacks>("Action", "Callbacks", "Print something")
+    public static let actionUI = Tweak<TweakCallbacks>("Actions", "UI", "Dismiss and show alert")
+    public static let actionConsole = Tweak<TweakCallbacks>("Actions", "Callbacks", "Print something")
     /*
 	Seriously, SpringAnimationTweakTemplate is *THE BEST* - here's what the equivalent would be if you were to make that by hand:
 

--- a/iOS Example/iOS Example/ExampleTweaks.swift
+++ b/iOS Example/iOS Example/ExampleTweaks.swift
@@ -32,8 +32,9 @@ public struct ExampleTweaks: TweakLibraryType {
 	// Tweaks are often used in combination with each other, so we have some templates available for ease-of-use:
 	public static let buttonAnimation = SpringAnimationTweakTemplate("Animation", "Button Animation", duration: 0.5) // Note: "duration" is optional, if you don't provide it, there's a sensible default!
 
-    public static let action = Tweak<TweakCallbacks>("Action", "Action", "action")
-	/*
+    public static let actionUI = Tweak<TweakCallbacks>("Action", "UI", "Dismiss and show alert")
+    public static let actionConsole = Tweak<TweakCallbacks>("Action", "Callbacks", "Print something")
+    /*
 	Seriously, SpringAnimationTweakTemplate is *THE BEST* - here's what the equivalent would be if you were to make that by hand:
 
 	public static let animationDuration = Tweak<Double>("Animation", "Button Animation", "Duration", defaultValue: 0.5, min: 0.0)
@@ -62,8 +63,9 @@ public struct ExampleTweaks: TweakLibraryType {
 
 			buttonAnimation,
             
-            action,
-
+            actionUI,
+            actionConsole,
+            
 			featureFlagMainScreenHelperText
 		]
 

--- a/iOS Example/iOS Example/ExampleTweaks.swift
+++ b/iOS Example/iOS Example/ExampleTweaks.swift
@@ -32,6 +32,7 @@ public struct ExampleTweaks: TweakLibraryType {
 	// Tweaks are often used in combination with each other, so we have some templates available for ease-of-use:
 	public static let buttonAnimation = SpringAnimationTweakTemplate("Animation", "Button Animation", duration: 0.5) // Note: "duration" is optional, if you don't provide it, there's a sensible default!
 
+    public static let action = Tweak<TweakCallbacks>("Action", "Action", "action")
 	/*
 	Seriously, SpringAnimationTweakTemplate is *THE BEST* - here's what the equivalent would be if you were to make that by hand:
 
@@ -60,6 +61,8 @@ public struct ExampleTweaks: TweakLibraryType {
 			fontSizeText2,
 
 			buttonAnimation,
+            
+            action,
 
 			featureFlagMainScreenHelperText
 		]

--- a/iOS Example/iOS Example/ExampleTweaks.swift
+++ b/iOS Example/iOS Example/ExampleTweaks.swift
@@ -34,6 +34,8 @@ public struct ExampleTweaks: TweakLibraryType {
 
     public static let actionUI = Tweak<TweakCallbacks>("Actions", "UI", "Dismiss and show alert")
     public static let actionConsole = Tweak<TweakCallbacks>("Actions", "Callbacks", "Print something")
+    public static let actionPush = Tweak<TweakCallbacks>("Actions", "UI", "Show another view controller")
+    
     /*
 	Seriously, SpringAnimationTweakTemplate is *THE BEST* - here's what the equivalent would be if you were to make that by hand:
 
@@ -65,6 +67,7 @@ public struct ExampleTweaks: TweakLibraryType {
             
             actionUI,
             actionConsole,
+            actionPush,
             
 			featureFlagMainScreenHelperText
 		]

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -64,13 +64,22 @@ class ViewController: UIViewController {
         tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText1) { self.titleLabel.textColor = $0; self.bodyLabel.textColor = $0 })
 tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitleLabel.textColor = $0 })
         _ = ExampleTweaks.action.addCallback {
+        _ = ExampleTweaks.actionUI.addCallback {
             self.presentedViewController?.dismiss(animated: true, completion: {
-                let alert = UIAlertController(title: "Hello", message: "🤖 says hello!", preferredStyle: .alert)
+                let alert = UIAlertController(title: "🤖", message: "I'm completely operational, and all my circuits are functioning perfectly.", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
         
                 self.present(alert, animated: true, completion: nil)
             })
         }
+        
+        _ = ExampleTweaks.actionConsole.addCallback {
+            print("🤖 I'm sorry Dave")
+        }
+        _ = ExampleTweaks.actionConsole.addCallback {
+            print("🤖 I'm afraid I can't do that")
+        }
+        
 
 		// The above examples used very concise syntax - that's because Swift makes it easy to write concisely!
 		// Of course, you can write binding closures in a more verbose syntax if you find it easier to read, like this:

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -66,7 +66,7 @@ class ViewController: UIViewController {
         // If you used `TweaksCallbacks` type, you can subscribe to those tweaks with callbacks.
         // Those will be run in order.
         // If you want to execute something only once, you can remove callback using identifier that `addCallback` method provides.
-        _ = ExampleTweaks.actionUI.addCallback {
+        _ = ExampleTweaks.actionUI.addCallback { _, _ in
             let showAlert = {
                 let alert = UIAlertController(title: "🤖", message: "I'm completely operational, and all my circuits are functioning perfectly.", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
@@ -81,14 +81,14 @@ class ViewController: UIViewController {
             }
         }
         
-        ExampleTweaks.actionConsole.addCallback {
+        ExampleTweaks.actionConsole.addCallback { _, _ in
             print("🤖 I'm sorry Dave")
         }
-        ExampleTweaks.actionConsole.addCallback {
+        ExampleTweaks.actionConsole.addCallback { _, _ in
             print("🤖 I'm afraid I can't do that")
         }
         
-        let callbackIdentifier = ExampleTweaks.actionConsole.addCallback {
+        let callbackIdentifier = ExampleTweaks.actionConsole.addCallback { _, _ in
             // this won't be run
             print("👩🏻‍🚀 <turns off HAL>")
         }

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -10,60 +10,59 @@ import UIKit
 import SwiftTweaks
 
 class ViewController: UIViewController {
-
-	private let titleLabel: UILabel = {
-		let label = UILabel()
-		label.textAlignment = .left
-		label.text = "SwiftTweaks"
-		return label
-	}()
-
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .left
+        label.text = "SwiftTweaks"
+        return label
+    }()
+    
     private let subtitleLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .left
         label.text = "github.com/Khan/SwiftTweaks"
         return label
     }()
-
-	private let bodyLabel: UILabel = {
-		let label = UILabel()
-		label.text = "Shake your device to bring up the Tweaks UI. Make your changes, and when you dismiss, you'll see 'em applied here! You can even force-quit the app and the changes will persist!"
-		label.numberOfLines = 0
-		label.lineBreakMode = .byWordWrapping
-		return label
-	}()
-
-	private let bounceButton: UIButton = {
-		let button = UIButton()
-		button.setTitle("Animate", for: UIControlState())
-		button.layer.cornerRadius = 5
-		button.contentEdgeInsets = UIEdgeInsets(top: 14, left: 32, bottom: 14, right: 32)
-		return button
-	}()
-
-	private var tweakBindings = Set<TweakBindingIdentifier>()
-	private var multiTweakBindings = Set<MultiTweakBindingIdentifier>()
-
-	override func viewDidLoad() {
-		super.viewDidLoad()
-
+    
+    private let bodyLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Shake your device to bring up the Tweaks UI. Make your changes, and when you dismiss, you'll see 'em applied here! You can even force-quit the app and the changes will persist!"
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        return label
+    }()
+    
+    private let bounceButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("Animate", for: UIControlState())
+        button.layer.cornerRadius = 5
+        button.contentEdgeInsets = UIEdgeInsets(top: 14, left: 32, bottom: 14, right: 32)
+        return button
+    }()
+    
+    private var tweakBindings = Set<TweakBindingIdentifier>()
+    private var multiTweakBindings = Set<MultiTweakBindingIdentifier>()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
         [titleLabel, subtitleLabel, bodyLabel, bounceButton].forEach(view.addSubview)
-
-		bounceButton.addTarget(self, action: #selector(self.bounceButtonPressed(_:)), for: .touchUpInside)
-
-		// Here's a demonstration of TweakLibraryType.bind() - the underlying tweak value is immediately applied, and the binding is re-called each time the tweak changes.
-		tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.featureFlagMainScreenHelperText) { self.bodyLabel.isHidden = !$0 })
-
-		// Bind is useful when you want to keep something up to date easily. 
-		// To demonstrate - let's apply a bunch of tweaks here in viewDidLoad, 
-		// which is only called once in the lifecycle of the view, yet these bindings will update whenever the underlying tweaks change!
-		// Note that we're holding on to the `bindingIdentifier`: to avoid memory leaks, we tear down these bindings in `deinit`
-		tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorTint) { self.bounceButton.backgroundColor = $0 })
-		tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorButtonText) { self.bounceButton.setTitleColor($0, for: .normal) })
-		tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorBackground) { self.view.backgroundColor = $0 })
+        
+        bounceButton.addTarget(self, action: #selector(bounceButtonPressed(_:)), for: .touchUpInside)
+        
+        // Here's a demonstration of TweakLibraryType.bind() - the underlying tweak value is immediately applied, and the binding is re-called each time the tweak changes.
+        tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.featureFlagMainScreenHelperText) { self.bodyLabel.isHidden = !$0 })
+        
+        // Bind is useful when you want to keep something up to date easily. 
+        // To demonstrate - let's apply a bunch of tweaks here in viewDidLoad, 
+        // which is only called once in the lifecycle of the view, yet these bindings will update whenever the underlying tweaks change!
+        // Note that we're holding on to the `bindingIdentifier`: to avoid memory leaks, we tear down these bindings in `deinit`
+        tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorTint) { self.bounceButton.backgroundColor = $0 })
+        tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorButtonText) { self.bounceButton.setTitleColor($0, for: .normal) })
+        tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorBackground) { self.view.backgroundColor = $0 })
         tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText1) { self.titleLabel.textColor = $0; self.bodyLabel.textColor = $0 })
-tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitleLabel.textColor = $0 })
-        _ = ExampleTweaks.action.addCallback {
+        tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitleLabel.textColor = $0 })
         // If you used `TweaksCallbacks` type, you can subscribe to those tweaks with callbacks.
         // Those will be run in order.
         // If you want to execute something only once, you can remove callback using identifier that `addCallback` method provides.
@@ -71,7 +70,7 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
             let showAlert = {
                 let alert = UIAlertController(title: "🤖", message: "I'm completely operational, and all my circuits are functioning perfectly.", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
-        
+                
                 self.present(alert, animated: true, completion: nil)
             }
             
@@ -95,71 +94,71 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
         }
         _ = try? ExampleTweaks.actionConsole.removeCallback(with: callbackIdentifier)
         
-		// The above examples used very concise syntax - that's because Swift makes it easy to write concisely!
-		// Of course, you can write binding closures in a more verbose syntax if you find it easier to read, like this:
-		tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.fontSizeText1) { fontSize in
-			self.titleLabel.font = UIFont.systemFont(ofSize: fontSize)
-		})
-
+        // The above examples used very concise syntax - that's because Swift makes it easy to write concisely!
+        // Of course, you can write binding closures in a more verbose syntax if you find it easier to read, like this:
+        tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.fontSizeText1) { fontSize in
+            self.titleLabel.font = UIFont.systemFont(ofSize: fontSize)
+        })
+        
         let binding = ExampleTweaks.bind(ExampleTweaks.title) { (title: StringOption) in
             self.titleLabel.text = title.value
         }
-		tweakBindings.insert(binding)
-
-		// Now let's look at a trickier example: let's say that you have a layout, and it depends on multiple tweaks. 
-		// In our case, we have tweaks for two font sizes, as well as two layout parameters (horizontal margins and vertical padding between the labels). 
-		// What we'll do in this case is create a layout closure, and then call it each time any of those tweaks change. You could also call an existing function (like `layoutSubviews` or something like that) instead of creating a closure.
-		// Note that inside this closure, we're calling `assign` to get the current value.
-		let tweaksToWatch: [TweakType] = [
-			ExampleTweaks.fontSizeText1,
-			ExampleTweaks.fontSizeText2,
-			ExampleTweaks.horizontalMargins,
-			ExampleTweaks.verticalMargins
-			]
-
-		let multipleBinding = ExampleTweaks.bindMultiple(tweaksToWatch) {
+        tweakBindings.insert(binding)
+        
+        // Now let's look at a trickier example: let's say that you have a layout, and it depends on multiple tweaks. 
+        // In our case, we have tweaks for two font sizes, as well as two layout parameters (horizontal margins and vertical padding between the labels). 
+        // What we'll do in this case is create a layout closure, and then call it each time any of those tweaks change. You could also call an existing function (like `layoutSubviews` or something like that) instead of creating a closure.
+        // Note that inside this closure, we're calling `assign` to get the current value.
+        let tweaksToWatch: [TweakType] = [
+            ExampleTweaks.fontSizeText1,
+            ExampleTweaks.fontSizeText2,
+            ExampleTweaks.horizontalMargins,
+            ExampleTweaks.verticalMargins
+        ]
+        
+        let multipleBinding = ExampleTweaks.bindMultiple(tweaksToWatch) {
             // This closure will be called immediately,
             // and then again each time *any* of the tweaksToWatch change.
-			self.layoutContentsOfView()
-		}
-		multiTweakBindings.insert(multipleBinding)
-	}
-
-	override func viewWillAppear(_ animated: Bool) {
-		super.viewWillAppear(animated)
-
-		// Use the `assign` value to get the currentValue of a tweak once.
-		// With `assign`, you get the value only once - when the tweak updates, you won't be notified.
-		// Since this is in viewWillAppear, though, this re-application will update right before the view appears onscreen!
-		view.backgroundColor = ExampleTweaks.assign(ExampleTweaks.colorBackground)
-	}
-
+            self.layoutContentsOfView()
+        }
+        multiTweakBindings.insert(multipleBinding)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // Use the `assign` value to get the currentValue of a tweak once.
+        // With `assign`, you get the value only once - when the tweak updates, you won't be notified.
+        // Since this is in viewWillAppear, though, this re-application will update right before the view appears onscreen!
+        view.backgroundColor = ExampleTweaks.assign(ExampleTweaks.colorBackground)
+    }
+    
     override func viewSafeAreaInsetsDidChange() {
         if #available(iOS 11.0, *) {
             super.viewSafeAreaInsetsDidChange()
             self.layoutContentsOfView()
         }
     }
-
-	override func didReceiveMemoryWarning() {
-		super.didReceiveMemoryWarning()
-		// Dispose of any resources that can be recreated.
-	}
-
-	deinit {
-		// Here's where we tear-down the tweak bindings that we used above.
-		self.tweakBindings.forEach(ExampleTweaks.unbind)
-		self.multiTweakBindings.forEach(ExampleTweaks.unbindMultiple)
-	}
-
-
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    deinit {
+        // Here's where we tear-down the tweak bindings that we used above.
+        self.tweakBindings.forEach(ExampleTweaks.unbind)
+        self.multiTweakBindings.forEach(ExampleTweaks.unbindMultiple)
+    }
+    
+    
     // MARK: Subviews
     private func layoutContentsOfView() {
         let titleLabelFontSize = ExampleTweaks.assign(ExampleTweaks.fontSizeText1)
         let bodyLabelFontSize = ExampleTweaks.assign(ExampleTweaks.fontSizeText2)
         let horizontalMargins = ExampleTweaks.assign(ExampleTweaks.horizontalMargins)
         let verticalGapBetweenLabels = ExampleTweaks.assign(ExampleTweaks.verticalMargins)
-
+        
         self.titleLabel.font = UIFont.systemFont(ofSize: titleLabelFontSize, weight: UIFont.Weight.bold)
         self.titleLabel.sizeToFit()
         let safeAreaInsets: UIEdgeInsets
@@ -177,15 +176,15 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
                 height: self.titleLabel.bounds.height
             )
         )
-
+        
         self.subtitleLabel.font = UIFont.systemFont(ofSize: bodyLabelFontSize)
         self.subtitleLabel.sizeToFit()
         self.subtitleLabel.frame = CGRect(
             origin: CGPoint(x: horizontalMargins, y: self.titleLabel.frame.maxY),
             size: CGSize(width: self.titleLabel.frame.width, height: self.subtitleLabel.frame.size.height)
         )
-
-
+        
+        
         self.bodyLabel.font = UIFont.systemFont(ofSize: bodyLabelFontSize)
         self.bodyLabel.frame = CGRect(
             origin: CGPoint(
@@ -195,7 +194,7 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
                 CGSize(width: self.view.bounds.width - horizontalMargins * 2, height: CGFloat.greatestFiniteMagnitude)
             )
         )
-
+        
         self.bounceButton.sizeToFit()
         self.bounceButton.frame = CGRect(
             origin: CGPoint(
@@ -204,66 +203,66 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
             ), size: self.bounceButton.bounds.size
         )
     }
-
-
-	// MARK: Events
-
-	@objc private func bounceButtonPressed(_ sender: UIButton) {
-
-		let originalFrame = self.bounceButton.frame
-
-		// To help make TweakGroupTemplateSpringAnimation even more useful - check this out:
-		UIView.animate(
-			springTweakTemplate: ExampleTweaks.buttonAnimation,
-			tweakStore: ExampleTweaks.defaultStore,
-			options: .beginFromCurrentState,
-			animations: { 
-				self.bounceButton.frame = originalFrame.offsetBy(dx: 0, dy: 200)
-			},
-			completion: { _ in
-				UIView.animate(
-					springTweakTemplate: ExampleTweaks.buttonAnimation,
-					tweakStore: ExampleTweaks.defaultStore,
-					options: .beginFromCurrentState,
-					animations: {
-						self.bounceButton.frame = originalFrame
-					},
-					completion: nil
-				)
-			}
-		)
-
-		/* Of course, you don't *have* to use the helper method; you can grab the individual tweaks quite easily:
-
-		let duration = ExampleTweaks.assign(ExampleTweaks.buttonAnimation.duration)
-		let delay = ExampleTweaks.assign(ExampleTweaks.buttonAnimation.delay)
-		let damping = ExampleTweaks.assign(ExampleTweaks.buttonAnimation.damping)
-		let velocity = ExampleTweaks.assign(ExampleTweaks.buttonAnimation.initialSpringVelocity)
-
-		UIView.animateWithDuration(
-			duration, 
-			delay: delay,
-			usingSpringWithDamping: damping,
-			initialSpringVelocity: velocity,
-			options: UIViewAnimationOptions.BeginFromCurrentState,
-			animations: { () -> Void in
-				self.bounceButton.frame = CGRectOffset(originalFrame, 0, 200)
-			}, 
-			completion: { _ in
-				UIView.animateWithDuration(
-					duration,
-					delay: delay,
-					usingSpringWithDamping: damping,
-					initialSpringVelocity: velocity,
-					options: UIViewAnimationOptions.BeginFromCurrentState,
-					animations: { () -> Void in
-						self.bounceButton.frame = originalFrame
-					},
-					completion: nil
-				)
-			}
-		)
-
-		*/
-	}
+    
+    
+    // MARK: Events
+    
+    @objc private func bounceButtonPressed(_ sender: UIButton) {
+        
+        let originalFrame = self.bounceButton.frame
+        
+        // To help make TweakGroupTemplateSpringAnimation even more useful - check this out:
+        UIView.animate(
+            springTweakTemplate: ExampleTweaks.buttonAnimation,
+            tweakStore: ExampleTweaks.defaultStore,
+            options: .beginFromCurrentState,
+            animations: { 
+                self.bounceButton.frame = originalFrame.offsetBy(dx: 0, dy: 200)
+        },
+            completion: { _ in
+                UIView.animate(
+                    springTweakTemplate: ExampleTweaks.buttonAnimation,
+                    tweakStore: ExampleTweaks.defaultStore,
+                    options: .beginFromCurrentState,
+                    animations: {
+                        self.bounceButton.frame = originalFrame
+                },
+                    completion: nil
+                )
+        }
+        )
+        
+        /* Of course, you don't *have* to use the helper method; you can grab the individual tweaks quite easily:
+         
+         let duration = ExampleTweaks.assign(ExampleTweaks.buttonAnimation.duration)
+         let delay = ExampleTweaks.assign(ExampleTweaks.buttonAnimation.delay)
+         let damping = ExampleTweaks.assign(ExampleTweaks.buttonAnimation.damping)
+         let velocity = ExampleTweaks.assign(ExampleTweaks.buttonAnimation.initialSpringVelocity)
+         
+         UIView.animateWithDuration(
+         duration, 
+         delay: delay,
+         usingSpringWithDamping: damping,
+         initialSpringVelocity: velocity,
+         options: UIViewAnimationOptions.BeginFromCurrentState,
+         animations: { () -> Void in
+         self.bounceButton.frame = CGRectOffset(originalFrame, 0, 200)
+         }, 
+         completion: { _ in
+         UIView.animateWithDuration(
+         duration,
+         delay: delay,
+         usingSpringWithDamping: damping,
+         initialSpringVelocity: velocity,
+         options: UIViewAnimationOptions.BeginFromCurrentState,
+         animations: { () -> Void in
+         self.bounceButton.frame = originalFrame
+         },
+         completion: nil
+         )
+         }
+         )
+         
+         */
+    }
 }

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -64,13 +64,22 @@ class ViewController: UIViewController {
         tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText1) { self.titleLabel.textColor = $0; self.bodyLabel.textColor = $0 })
 tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitleLabel.textColor = $0 })
         _ = ExampleTweaks.action.addCallback {
+        // If you used `TweaksCallbacks` type, you can subscribe to those tweaks with callbacks.
+        // Those will be run in order.
+        // If you want to execute something only once, you can remove callback using identifier that `addCallback` method provides.
         _ = ExampleTweaks.actionUI.addCallback {
-            self.presentedViewController?.dismiss(animated: true, completion: {
+            let showAlert = {
                 let alert = UIAlertController(title: "🤖", message: "I'm completely operational, and all my circuits are functioning perfectly.", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
         
                 self.present(alert, animated: true, completion: nil)
-            })
+            }
+            
+            if let presentedViewController = self.presentedViewController {
+                presentedViewController.dismiss(animated: true, completion: showAlert)
+            } else {
+                showAlert()
+            }
         }
         
         _ = ExampleTweaks.actionConsole.addCallback {
@@ -79,6 +88,12 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
         _ = ExampleTweaks.actionConsole.addCallback {
             print("🤖 I'm afraid I can't do that")
         }
+        
+        let callbackIdentifier = ExampleTweaks.actionConsole.addCallback {
+            // this won't be run
+            print("👩🏻‍🚀 <turns off HAL>")
+        }
+        ExampleTweaks.actionConsole.removeCallback(with: callbackIdentifier)
         
 		// The above examples used very concise syntax - that's because Swift makes it easy to write concisely!
 		// Of course, you can write binding closures in a more verbose syntax if you find it easier to read, like this:

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -82,10 +82,10 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
             }
         }
         
-        _ = ExampleTweaks.actionConsole.addCallback {
+        ExampleTweaks.actionConsole.addCallback {
             print("🤖 I'm sorry Dave")
         }
-        _ = ExampleTweaks.actionConsole.addCallback {
+        ExampleTweaks.actionConsole.addCallback {
             print("🤖 I'm afraid I can't do that")
         }
         

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -62,7 +62,15 @@ class ViewController: UIViewController {
 		tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorButtonText) { self.bounceButton.setTitleColor($0, for: .normal) })
 		tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorBackground) { self.view.backgroundColor = $0 })
         tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText1) { self.titleLabel.textColor = $0; self.bodyLabel.textColor = $0 })
-        tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitleLabel.textColor = $0 })
+tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitleLabel.textColor = $0 })
+        _ = ExampleTweaks.action.addCallback {
+            self.presentedViewController?.dismiss(animated: true, completion: {
+                let alert = UIAlertController(title: "Hello", message: "🤖 says hello!", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+        
+                self.present(alert, animated: true, completion: nil)
+            })
+        }
 
 		// The above examples used very concise syntax - that's because Swift makes it easy to write concisely!
 		// Of course, you can write binding closures in a more verbose syntax if you find it easier to read, like this:

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -80,7 +80,6 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
             print("🤖 I'm afraid I can't do that")
         }
         
-
 		// The above examples used very concise syntax - that's because Swift makes it easy to write concisely!
 		// Of course, you can write binding closures in a more verbose syntax if you find it easier to read, like this:
 		tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.fontSizeText1) { fontSize in

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -81,6 +81,15 @@ class ViewController: UIViewController {
             }
         }
         
+        ExampleTweaks.actionPush.addCallback { _, viewController in
+            guard let navigationController = viewController?.navigationController else {
+                return assertionFailure()
+            }
+            
+            let exampleViewController = ExampleCallbackViewController(nibName: nil, bundle: nil)
+            navigationController.pushViewController(exampleViewController, animated: true)
+        }
+        
         ExampleTweaks.actionConsole.addCallback { _, _ in
             print("🤖 I'm sorry Dave")
         }

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -93,7 +93,7 @@ tweakBindings.insert(ExampleTweaks.bind(ExampleTweaks.colorText2) { self.subtitl
             // this won't be run
             print("👩🏻‍🚀 <turns off HAL>")
         }
-        ExampleTweaks.actionConsole.removeCallback(with: callbackIdentifier)
+        _ = try? ExampleTweaks.actionConsole.removeCallback(with: callbackIdentifier)
         
 		// The above examples used very concise syntax - that's because Swift makes it easy to write concisely!
 		// Of course, you can write binding closures in a more verbose syntax if you find it easier to read, like this:


### PR DESCRIPTION
I've added support for actions inside Tweaks.
There are times when we want to execute some custom code on test builds. Currently, we bind to some `Bool` tweak and toggle it to run the code, but I wanted a cleaner, more extendable solution.

The implementation isn't as clean as I would like but I didn't want to refactor the whole architecture of Tweaks to remove certain assumptions that each tweak has meaningful value or to provide a separate data source for actions inside Tweaks.

It's a good start, a working solution that somewhat still makes sense within Tweaks world and can be improved in the future when more non-data types will be supported.