### PR TITLE
#75 - Update Swift 3 syntax for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ public static let colorTint = Tweak("General", "Colors", "Tint", UIColor.blueCol
 There are also helpful `TweakGroupTemplate` types, so you can quickly declare commonly-used-together combos. They all have sensible defaults, but of course, you can set your own!
 ```swift
 // Controls delay and duration for UIView.animate
-// Use it with UIView.animateWithBasicAnimationTweakTemplate
+// Use it with UIView.animate(basicTweakTemplate:...)
 public static let basicAnimation = BasicAnimationTweakTemplate("Animation", "Basic Animation")
 
 // Controls delay, duration, damping, and initial spring velocity for UIView.animate
-// Use it with UIView.animateWithSpringAnimationTweakTemplate
+// Use it with UIView.animate(springTweakTemplate:...)
 public static let springAnimation = SpringAnimationTweakTemplate("Animation", "Spring Animation")
 
 // Controls shadow color, radius, offset, and opacity for CALayer
-// Use it with CALayer.applyShadowTweakTemplate
+// Use it with CALayer.apply(shadowTweakTemplate:...)
 public static let shadowTweak = ShadowTweakTemplate("Shadows", "Button Shadow")
 
 // Controls top/right/bottom/left for UIEdgeInsets

--- a/SwiftTweaks/CALayer+ShadowTweakTemplate.swift
+++ b/SwiftTweaks/CALayer+ShadowTweakTemplate.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public extension CALayer {
 	/// A shortcut for applying a ShadowTweakTemplate to a CALayer.
-	public func applyShadowTweakTemplate(_ tweakTemplate: ShadowTweakTemplate, fromTweakStore tweakStore: TweakStore) {
+	public func apply(shadowTweakTemplate tweakTemplate: ShadowTweakTemplate, fromTweakStore tweakStore: TweakStore) {
 		self.shadowColor = tweakStore.assign(tweakTemplate.color).cgColor
 		self.shadowOpacity = Float(tweakStore.assign(tweakTemplate.opacity))
 		self.shadowOffset = CGSize(width: 0, height: tweakStore.assign(tweakTemplate.offsetY))

--- a/SwiftTweaks/UIView+BasicAnimationTweakTemplate.swift
+++ b/SwiftTweaks/UIView+BasicAnimationTweakTemplate.swift
@@ -12,16 +12,16 @@ public extension UIView {
 
 	/// A convenience wrapper for iOS-style spring animations.
 	/// Under the hood, it gets the current value for each tweak in the group, and uses that in an animation.
-	public static func animateWithBasicAnimationTweakTemplate(
-		_ basicAnimationTweakTemplate: BasicAnimationTweakTemplate,
+	public static func animate(
+		basicTweakTemplate: BasicAnimationTweakTemplate,
 		tweakStore: TweakStore,
 		options: UIViewAnimationOptions,
 		animations: @escaping () -> Void,
 		completion: ((Bool) -> Void)?
 		) {
 		UIView.animate(
-			withDuration: tweakStore.assign(basicAnimationTweakTemplate.duration),
-			delay: tweakStore.assign(basicAnimationTweakTemplate.delay),
+			withDuration: tweakStore.assign(basicTweakTemplate.duration),
+			delay: tweakStore.assign(basicTweakTemplate.delay),
 			options: options,
 			animations: animations,
 			completion: completion

--- a/SwiftTweaks/UIView+TweakGroupTemplateSpringAnimation.swift
+++ b/SwiftTweaks/UIView+TweakGroupTemplateSpringAnimation.swift
@@ -12,18 +12,18 @@ public extension UIView {
 
 	/// A convenience wrapper for iOS-style spring animations.
 	/// Under the hood, it gets the current value for each tweak in the group, and uses that in an animation.
-	public static func animateWithSpringAnimationTweakTemplate(
-		_ springAnimationTweakTemplate: SpringAnimationTweakTemplate,
+	public static func animate(
+		springTweakTemplate: SpringAnimationTweakTemplate,
 		tweakStore: TweakStore,
 		options: UIViewAnimationOptions,
 		animations: @escaping () -> Void,
 		completion: ((Bool) -> Void)?
 	) {
 		UIView.animate(
-			withDuration: tweakStore.assign(springAnimationTweakTemplate.duration),
-			delay: tweakStore.assign(springAnimationTweakTemplate.delay),
-			usingSpringWithDamping: tweakStore.assign(springAnimationTweakTemplate.damping),
-			initialSpringVelocity: tweakStore.assign(springAnimationTweakTemplate.initialSpringVelocity),
+			withDuration: tweakStore.assign(springTweakTemplate.duration),
+			delay: tweakStore.assign(springTweakTemplate.delay),
+			usingSpringWithDamping: tweakStore.assign(springTweakTemplate.damping),
+			initialSpringVelocity: tweakStore.assign(springTweakTemplate.initialSpringVelocity),
 			options: options,
 			animations: animations,
 			completion: completion

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -146,16 +146,16 @@ class ViewController: UIViewController {
 		let originalFrame = self.bounceButton.frame
 
 		// To help make TweakGroupTemplateSpringAnimation even more useful - check this out:
-		UIView.animateWithSpringAnimationTweakTemplate(
-			ExampleTweaks.buttonAnimation,
+		UIView.animate(
+			springTweakTemplate: ExampleTweaks.buttonAnimation,
 			tweakStore: ExampleTweaks.defaultStore,
 			options: .beginFromCurrentState,
 			animations: { 
 				self.bounceButton.frame = originalFrame.offsetBy(dx: 0, dy: 200)
 			},
 			completion: { _ in
-				UIView.animateWithSpringAnimationTweakTemplate(
-					ExampleTweaks.buttonAnimation,
+				UIView.animate(
+					springTweakTemplate: ExampleTweaks.buttonAnimation,
 					tweakStore: ExampleTweaks.defaultStore,
 					options: .beginFromCurrentState,
 					animations: {


### PR DESCRIPTION
#75 - Update Swift 3 syntax for extensions for UIView extensions for BasicAnimationTweakTemplate and SpringAnimationTweakTemplate, and CALayer extension for ShadowTweakTemplate