### PR TITLE
Fix crash in loadFromDisk() method in TweakDiskPersistency class

### DIFF
--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -71,7 +71,7 @@ private final class TweakDiskPersistency {
 
 	private let queue = DispatchQueue(label: "org.khanacademy.swift_tweaks.disk_persistency", attributes: [])
 
-	private static let dataClassName = "TweakDiskPersistency.Data"
+	private static let dataClassName = String(describing: TweakDiskPersistency.Data.self)
 
 	init(identifier: String) {
 		NSKeyedUnarchiver.setClass(TweakDiskPersistency.Data.self, forClassName: TweakDiskPersistency.dataClassName)
@@ -118,6 +118,8 @@ private final class TweakDiskPersistency {
 
 		init(cache: TweakCache) {
 			self.cache = cache
+            
+            super.init()
 		}
 
 		@objc convenience init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This commit should solve the issue which ends with a crash and the message:
> The application crash with the message: `Terminating app due to uncaught exception 'NSInvalidUnarchiveOperationException', reason: '*** -[NSKeyedUnarchiver decodeObjectForKey:]: cannot decode object of class (Data) for key (root); the class may be defined in source code or a library that is not linked'