### PR TITLE
Adapt initializer of tweak with string option for swift 4.1

### DIFF
--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -92,7 +92,7 @@ extension Tweak where T == StringOption {
 	public init(_ collectionName: String, _ groupName: String, _ tweakName: String, options: [String], defaultValue: String? = nil) {
 		precondition(!options.isEmpty, "Options list cannot be empty (stringList tweak \"\(tweakName)\")")
 		precondition(
-			defaultValue == nil || (defaultValue != nil && options.contains(defaultValue!) == false),
+			defaultValue == nil || options.contains(defaultValue!),
 			"The default value \"\(String(describing: defaultValue))\" of the stringList tweak \"\(tweakName)\" must be in the list of options \"\(options)\""
 		)
 

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -88,21 +88,34 @@ extension Tweak where T: Comparable {
 	}
 }
 
-extension Tweak {
-	// This can't be an initializer because generic types apparently can't handle fixed-type initializers
-	public static func stringList(_ collectionName: String, _ groupName: String, _ tweakName: String, options: [String], defaultValue: String?=nil) -> Tweak<StringOption> {
+extension Tweak where T == StringOption {
+	public init(_ collectionName: String, _ groupName: String, _ tweakName: String, options: [String], defaultValue: String? = nil) {
 		precondition(!options.isEmpty, "Options list cannot be empty (stringList tweak \"\(tweakName)\")")
 		precondition(
-			defaultValue == nil || (defaultValue != nil && options.index(of: defaultValue!) != nil),
+			defaultValue == nil || (defaultValue != nil && options.contains(defaultValue!) == false),
 			"The default value \"\(String(describing: defaultValue))\" of the stringList tweak \"\(tweakName)\" must be in the list of options \"\(options)\""
 		)
 
-		return Tweak<StringOption>(
+		self.init(
 			collectionName: collectionName,
 			groupName: groupName,
 			tweakName: tweakName,
 			defaultValue: StringOption(value: defaultValue ?? options[0]),
 			options: options.map(StringOption.init)
+		)
+	}
+}
+
+extension Tweak {
+	@available(*, deprecated, message: "replaced by 'init(_:_:_options:defaultValue:)'", renamed: "init(_:_:_options:defaultValue:)")
+	public static func stringList(_ collectionName: String, _ groupName: String, _ tweakName: String, options: [String], defaultValue: String? = nil) -> Tweak<StringOption> {
+
+		return Tweak<StringOption>(
+		collectionName,
+		groupName,
+		tweakName,
+		options: options,
+		defaultValue: defaultValue
 		)
 	}
 }

--- a/iOS Example/iOS Example/ExampleTweaks.swift
+++ b/iOS Example/iOS Example/ExampleTweaks.swift
@@ -27,7 +27,7 @@ public struct ExampleTweaks: TweakLibraryType {
 	public static let colorText1 = Tweak("Text", "Color", "text-1", UIColor.black)
 	public static let colorText2 = Tweak("Text", "Color", "text-2", UIColor(hue: 213/255, saturation: 0.07, brightness: 0.58, alpha: 1))
 
-	public static let title = Tweak<StringOption>.stringList("Text", "Text", "Title", options: ["SwiftTweaks", "Welcome!", "Example"])
+    public static let title = Tweak("Text", "Text", "Title", options: ["SwiftTweaks", "Welcome!", "Example"])
 	public static let subtitle = Tweak<String>("Text", "Text", "Subtitle", "Subtitle")
 
 	// Tweaks are often used in combination with each other, so we have some templates available for ease-of-use:


### PR DESCRIPTION
Started from Swift 4.1, extension supports conditional conformance, so fixed-type initializer of generic type now possible.

This PR makes `Tweak<StringOption>` have a normal initializer like other `Tweak<T>` types.