### PR TITLE
Support app groups

### DIFF
--- a/SwiftTweaks.podspec
+++ b/SwiftTweaks.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.authors            = "Khan Academy", "Bryan Clark"
   s.social_media_url   = "https://twitter.com/khanacademy"
 
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "9.0"
 
   s.source       = { :git => "https://github.com/Khan/SwiftTweaks.git", :tag => "v4.0.2", :submodules => true }
   s.source_files = "SwiftTweaks/**/*.swift"

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -23,8 +23,8 @@ internal final class TweakPersistency {
 
 	private var tweakCache: TweakCache = [:]
 
-	init(identifier: String) {
-		self.diskPersistency = TweakDiskPersistency(identifier: identifier)
+	init(identifier: String, appGroup: String?) {
+		self.diskPersistency = TweakDiskPersistency(identifier: identifier, appGroup: appGroup)
 		self.tweakCache = self.diskPersistency.loadFromDisk()
 	}
 
@@ -62,8 +62,14 @@ internal final class TweakPersistency {
 private final class TweakDiskPersistency {
 	private let fileURL: URL
 
-	private static func fileURLForIdentifier(_ identifier: String) -> URL {
-		return try! FileManager().url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+	private static func fileURLForIdentifier(_ identifier: String, appGroup: String?) -> URL {
+		guard let appGroupName = appGroup else {
+			return try! FileManager().url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+				.appendingPathComponent("SwiftTweaks")
+				.appendingPathComponent("\(identifier)")
+				.appendingPathExtension("db")
+		}
+		return FileManager().containerURL(forSecurityApplicationGroupIdentifier: appGroupName)!
 			.appendingPathComponent("SwiftTweaks")
 			.appendingPathComponent("\(identifier)")
 			.appendingPathExtension("db")
@@ -73,11 +79,11 @@ private final class TweakDiskPersistency {
 
 	private static let dataClassName = "TweakDiskPersistency.Data"
 
-	init(identifier: String) {
+	init(identifier: String, appGroup: String?) {
 		NSKeyedUnarchiver.setClass(TweakDiskPersistency.Data.self, forClassName: TweakDiskPersistency.dataClassName)
 		NSKeyedArchiver.setClassName(TweakDiskPersistency.dataClassName, for: TweakDiskPersistency.Data.self)
 
-		self.fileURL = TweakDiskPersistency.fileURLForIdentifier(identifier)
+		self.fileURL = TweakDiskPersistency.fileURLForIdentifier(identifier, appGroup: appGroup)
 		self.ensureDirectoryExists()
 	}
 

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -34,8 +34,8 @@ public final class TweakStore {
 
 	/// Creates a TweakStore, with information persisted on-disk. 
 	/// If you want to have multiple TweakStores in your app, you can pass in a unique storeName to keep it separate from others on disk.
-	public init(tweaks: [TweakClusterType], storeName: String = "Tweaks", enabled: Bool) {
-		self.persistence = TweakPersistency(identifier: storeName)
+	public init(tweaks: [TweakClusterType], storeName: String = "Tweaks", enabled: Bool, appGroup: String? = nil) {
+		self.persistence = TweakPersistency(identifier: storeName, appGroup: appGroup)
 		self.storeName = storeName
 		self.enabled = enabled
 		self.allTweaks = Set(tweaks.reduce([]) { $0 + $1.tweakCluster })


### PR DESCRIPTION
Fixes https://github.com/Khan/SwiftTweaks/issues/128

This PR adds support for iOS app groups. This enables the tweaks to be accessed via iOS extensions that might utilize internal variables common to the main app (think API domain names and the like). I implemented this using a default, optional parameter on the main initializer which is a non-breaking API change for implementing developers. All other changes occurred on internal classes.

I already pulled my branch into my side project app and confirmed it to work. Since this depends upon several OS security mechanisms to work correctly (FileManager's containerURL() function, and the general OS sandbox security mechanisms), I couldn't figure out a way to appropriately unit test this new functionality. If you have thoughts around that I'd be happy to add them. 