### PR TITLE
Support Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Currently, you can tweak the following types:
 
 - `Bool`
 - `Int`
+- `Int8`
+- `UInt8`
+- `Int16`
+- `UInt16`
+- `Int32`
+- `UInt32`
+- `Int64`
+- `UInt64`
 - `CGFloat`
 - `Double`
 - `UIColor`

--- a/SwiftTweaks/FloatingTweakGroupViewController.swift
+++ b/SwiftTweaks/FloatingTweakGroupViewController.swift
@@ -30,7 +30,8 @@ internal final class FloatingTweakGroupViewController: UIViewController {
 
 	static func editingSupported(forTweak tweak: AnyTweak) -> Bool {
 		switch tweak.tweakViewDataType {
-		case .boolean, .integer, .cgFloat, .double, .action:
+		case .boolean, .integer, .int8, .int16, .int32, .int64,
+             .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .double, .action:
 			return true
 		case .uiColor, .stringList, .string:
 			return false
@@ -341,7 +342,8 @@ extension FloatingTweakGroupViewController: UITableViewDelegate {
 			if let actionTweak = tweak.tweak as? Tweak<TweakAction> {            
 				actionTweak.defaultValue.evaluateAllClosures()
 			}
-		case .boolean, .cgFloat, .double, .integer, .string, .stringList, .uiColor:
+		case .boolean, .cgFloat, .double, .integer, .int8, .int16, .int32, .int64,
+             .uInt8, .uInt16, .uInt32, .uInt64, .string, .stringList, .uiColor:
 			break
 		}
 		self.tableView.deselectRow(at: indexPath, animated: true)

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -136,6 +136,62 @@ extension Tweak: TweakType {
 				max: maximumValue as? Int,
 				stepSize: stepSize as? Int
 			)
+		case .int8:
+			return .int8(
+				defaultValue: defaultValue as! Int8,
+				min: minimumValue as? Int8,
+				max: maximumValue as? Int8,
+				stepSize: stepSize as? Int8
+			)
+		case .int16:
+			return .int16(
+				defaultValue: defaultValue as! Int16,
+				min: minimumValue as? Int16,
+				max: maximumValue as? Int16,
+				stepSize: stepSize as? Int16
+			)
+		case .int32:
+			return .int32(
+				defaultValue: defaultValue as! Int32,
+				min: minimumValue as? Int32,
+				max: maximumValue as? Int32,
+				stepSize: stepSize as? Int32
+			)
+		case .int64:
+			return .int64(
+				defaultValue: defaultValue as! Int64,
+				min: minimumValue as? Int64,
+				max: maximumValue as? Int64,
+				stepSize: stepSize as? Int64
+			)
+		case .uInt8:
+			return .uInt8(
+				defaultValue: defaultValue as! UInt8,
+				min: minimumValue as? UInt8,
+				max: maximumValue as? UInt8,
+				stepSize: stepSize as? UInt8
+			)
+		case .uInt16:
+			return .uInt16(
+				defaultValue: defaultValue as! UInt16,
+				min: minimumValue as? UInt16,
+				max: maximumValue as? UInt16,
+				stepSize: stepSize as? UInt16
+			)
+		case .uInt32:
+			return .uInt32(
+				defaultValue: defaultValue as! UInt32,
+				min: minimumValue as? UInt32,
+				max: maximumValue as? UInt32,
+				stepSize: stepSize as? UInt32
+			)
+		case .uInt64:
+			return .uInt64(
+				defaultValue: defaultValue as! UInt64,
+				min: minimumValue as? UInt64,
+				max: maximumValue as? UInt64,
+				stepSize: stepSize as? UInt64
+			)
 		case .cgFloat:
 			return .float(
 				defaultValue: defaultValue as! CGFloat,

--- a/SwiftTweaks/TweakBinding.swift
+++ b/SwiftTweaks/TweakBinding.swift
@@ -21,7 +21,7 @@ internal struct TweakBinding<T: TweakableType>: TweakBindingType{
 
 	func applyBindingWithValue(_ value: TweakableType) {
 		switch type(of: value).tweakViewDataType {
-		case .boolean, .integer, .cgFloat, .action, .double, .uiColor, .string, .stringList:
+		case .boolean, .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .action, .double, .uiColor, .string, .stringList:
 			binding(value as! T)
 		}
 	}

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -138,7 +138,7 @@ extension TweakCollectionViewController: UITableViewDelegate {
 			let actionTweak = tweak.tweak as! Tweak<TweakAction>
 			actionTweak.defaultValue.evaluateAllClosures()
 			self.hapticsPlayer.playNotificationSuccess()
-		case .integer, .cgFloat, .double, .string:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .double, .string:
 			let cell = tableView.cellForRow(at: indexPath) as! TweakTableCell
 			cell.startEditingTextField()
 		case .boolean:

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -168,6 +168,14 @@ private final class TweakDiskPersistency {
 		private static func tweakableTypeWithAnyObject(_ anyObject: AnyObject, withType type: TweakViewDataType) -> TweakableType? {
 			switch type {
 			case .integer: return anyObject as? Int
+			case .int8: return anyObject as? Int8
+			case .int16: return anyObject as? Int16
+			case .int32: return anyObject as? Int32
+			case .int64: return anyObject as? Int64
+			case .uInt8: return anyObject as? UInt8
+			case .uInt16: return anyObject as? UInt16
+			case .uInt32: return anyObject as? UInt32
+			case .uInt64: return anyObject as? UInt64
 			case .boolean: return anyObject as? Bool
 			case .cgFloat: return anyObject as? CGFloat
 			case .double: return anyObject as? Double
@@ -190,6 +198,14 @@ private extension TweakViewDataType {
 		switch self {
 		case .boolean: return "boolean"
 		case .integer: return "integer"
+		case .int8: return "int8"
+		case .int16: return "int16"
+		case .int32: return "int32"
+		case .int64: return "int64"
+		case .uInt8: return "uInt8"
+		case .uInt16: return "uInt16"
+		case .uInt32: return "uInt32"
+		case .uInt64: return "uInt64"
 		case .cgFloat: return "cgfloat"
 		case .double: return "double"
 		case .uiColor: return "uicolor"
@@ -206,6 +222,14 @@ private extension TweakableType {
 		switch type(of: self).tweakViewDataType {
 			case .boolean: return self as! Bool as AnyObject
 			case .integer: return self as! Int as AnyObject
+			case .int8: return self as! Int8 as AnyObject
+			case .int16: return self as! Int16 as AnyObject
+			case .int32: return self as! Int32 as AnyObject
+			case .int64: return self as! Int64 as AnyObject
+			case .uInt8: return self as! UInt8 as AnyObject
+			case .uInt16: return self as! UInt16 as AnyObject
+			case .uInt32: return self as! UInt32 as AnyObject
+			case .uInt64: return self as! UInt64 as AnyObject
 			case .cgFloat: return self as! CGFloat as AnyObject
 			case .double: return self as! Double as AnyObject
 			case .uiColor: return self as! UIColor

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -144,6 +144,30 @@ public final class TweakStore {
 		case let .integer(defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			let currentValue = cachedValue as? Int ?? defaultValue
 			return .integer(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .int8(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? Int8 ?? defaultValue
+			return .int8(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .int16(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? Int16 ?? defaultValue
+			return .int16(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .int32(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? Int32 ?? defaultValue
+			return .int32(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .int64(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? Int64 ?? defaultValue
+			return .int64(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .uInt8(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? UInt8 ?? defaultValue
+			return .uInt8(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .uInt16(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? UInt16 ?? defaultValue
+			return .uInt16(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .uInt32(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? UInt32 ?? defaultValue
+			return .uInt32(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .uInt64(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? UInt64 ?? defaultValue
+			return .uInt64(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
 		case let .float(defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			let currentValue = cachedValue as? CGFloat ?? defaultValue
 			return .float(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -31,7 +31,7 @@ internal final class TweakTableCell: UITableViewCell {
 	internal var isInFloatingTweakGroupWindow = false
 
 	private var accessory = UIView()
-
+    
 	private let switchControl: UISwitch = {
 		let switchControl = UISwitch()
 		switchControl.onTintColor = AppTheme.Colors.controlTinted
@@ -76,7 +76,7 @@ internal final class TweakTableCell: UITableViewCell {
 		textField.delegate = self
 
 		detailTextLabel!.textColor = AppTheme.Colors.textPrimary
-
+        
 		let touchHighlightView = UIView()
 		touchHighlightView.backgroundColor = AppTheme.Colors.tableCellTouchHighlight
 		self.selectedBackgroundView = touchHighlightView
@@ -109,7 +109,7 @@ internal final class TweakTableCell: UITableViewCell {
 			switchControl.sizeToFit()
 			accessory.bounds = switchControl.bounds
 
-		case .integer, .float, .doubleTweak:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .float, .doubleTweak:
 			stepperControl.sizeToFit()
 
 			let textFrame = CGRect(
@@ -222,7 +222,7 @@ internal final class TweakTableCell: UITableViewCell {
 			colorChit.isHidden = true
 			disclosureArrow.isHidden = true
 			selectionStyle = .none
-		case .integer, .float, .doubleTweak:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .float, .doubleTweak:
 			switchControl.isHidden = true
 			textField.isHidden = false
 			stepperControl.isHidden = false
@@ -276,7 +276,7 @@ internal final class TweakTableCell: UITableViewCell {
 			switchControl.isOn = value
 			textFieldEnabled = false
 
-		case .integer:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64:
 			let doubleValue = viewData.doubleValue!
 			self.updateStepper(value: doubleValue, stepperValues: viewData.stepperValues!)
 
@@ -347,6 +347,30 @@ internal final class TweakTableCell: UITableViewCell {
 		case let .integer(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			viewData = TweakViewData(type: .integer, value: Int(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
 			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .int8(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .int8, value: Int8(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .int16(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .int16, value: Int16(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .int32(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .int32, value: Int32(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .int64(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .int64, value: Int64(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .uInt8(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .uInt8, value: UInt8(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .uInt16(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .uInt16, value: UInt16(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .uInt32(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .uInt32, value: UInt32(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .uInt64(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .uInt64, value: UInt64(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
 		case let .float(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			viewData = TweakViewData(type: .cgFloat, value: CGFloat(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
 			delegate?.tweakCellDidChangeCurrentValue(self)
@@ -374,6 +398,62 @@ extension TweakTableCell: UITextFieldDelegate {
 		case let .integer(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
 			if let text = textField.text, let newValue = Int(text) {
 				viewData = TweakViewData(type: .integer, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .int8(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = Int8(text) {
+				viewData = TweakViewData(type: .int8, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .int16(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = Int16(text) {
+				viewData = TweakViewData(type: .int16, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .int32(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = Int32(text) {
+				viewData = TweakViewData(type: .int32, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .int64(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = Int64(text) {
+				viewData = TweakViewData(type: .int64, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .uInt8(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = UInt8(text) {
+				viewData = TweakViewData(type: .uInt8, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .uInt16(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = UInt16(text) {
+				viewData = TweakViewData(type: .uInt16, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .uInt32(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = UInt32(text) {
+				viewData = TweakViewData(type: .uInt32, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .uInt64(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = UInt64(text) {
+				viewData = TweakViewData(type: .uInt64, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
 				delegate?.tweakCellDidChangeCurrentValue(self)
 			} else {
 				updateSubviews()

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -12,6 +12,14 @@ import UIKit
 internal enum TweakViewData {
 	case boolean(value: Bool, defaultValue: Bool)
 	case integer(value: Int, defaultValue: Int, min: Int?, max: Int?, stepSize: Int?)
+	case int8(value: Int8, defaultValue: Int8, min: Int8?, max: Int8?, stepSize: Int8?)
+	case int16(value: Int16, defaultValue: Int16, min: Int16?, max: Int16?, stepSize: Int16?)
+	case int32(value: Int32, defaultValue: Int32, min: Int32?, max: Int32?, stepSize: Int32?)
+	case int64(value: Int64, defaultValue: Int64, min: Int64?, max: Int64?, stepSize: Int64?)
+	case uInt8(value: UInt8, defaultValue: UInt8, min: UInt8?, max: UInt8?, stepSize: UInt8?)
+	case uInt16(value: UInt16, defaultValue: UInt16, min: UInt16?, max: UInt16?, stepSize: UInt16?)
+	case uInt32(value: UInt32, defaultValue: UInt32, min: UInt32?, max: UInt32?, stepSize: UInt32?)
+	case uInt64(value: UInt64, defaultValue: UInt64, min: UInt64?, max: UInt64?, stepSize: UInt64?)
 	case float(value: CGFloat, defaultValue: CGFloat, min: CGFloat?, max: CGFloat?, stepSize: CGFloat?)
 	case doubleTweak(value: Double, defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(value: UIColor, defaultValue: UIColor)
@@ -25,6 +33,30 @@ internal enum TweakViewData {
 			self = .boolean(value: value as! Bool, defaultValue: defaultValue as! Bool)
 		case .uiColor:
 			self = .color(value: value as! UIColor, defaultValue: defaultValue as! UIColor)
+		case .int8:
+			let clippedValue = clip(value as! Int8, minimum as? Int8, maximum as? Int8)
+			self = .int8(value: clippedValue, defaultValue: defaultValue as! Int8, min: minimum as? Int8, max: maximum as? Int8, stepSize: stepSize as? Int8)
+		case .int16:
+			let clippedValue = clip(value as! Int16, minimum as? Int16, maximum as? Int16)
+			self = .int16(value: clippedValue, defaultValue: defaultValue as! Int16, min: minimum as? Int16, max: maximum as? Int16, stepSize: stepSize as? Int16)
+		case .int32:
+			let clippedValue = clip(value as! Int32, minimum as? Int32, maximum as? Int32)
+			self = .int32(value: clippedValue, defaultValue: defaultValue as! Int32, min: minimum as? Int32, max: maximum as? Int32, stepSize: stepSize as? Int32)
+		case .int64:
+			let clippedValue = clip(value as! Int64, minimum as? Int64, maximum as? Int64)
+			self = .int64(value: clippedValue, defaultValue: defaultValue as! Int64, min: minimum as? Int64, max: maximum as? Int64, stepSize: stepSize as? Int64)
+		case .uInt8:
+			let clippedValue = clip(value as! UInt8, minimum as? UInt8, maximum as? UInt8)
+			self = .uInt8(value: clippedValue, defaultValue: defaultValue as! UInt8, min: minimum as? UInt8, max: maximum as? UInt8, stepSize: stepSize as? UInt8)
+		case .uInt16:
+			let clippedValue = clip(value as! UInt16, minimum as? UInt16, maximum as? UInt16)
+			self = .uInt16(value: clippedValue, defaultValue: defaultValue as! UInt16, min: minimum as? UInt16, max: maximum as? UInt16, stepSize: stepSize as? UInt16)
+		case .uInt32:
+			let clippedValue = clip(value as! UInt32, minimum as? UInt32, maximum as? UInt32)
+			self = .uInt32(value: clippedValue, defaultValue: defaultValue as! UInt32, min: minimum as? UInt32, max: maximum as? UInt32, stepSize: stepSize as? UInt32)
+		case .uInt64:
+			let clippedValue = clip(value as! UInt64, minimum as? UInt64, maximum as? UInt64)
+			self = .uInt64(value: clippedValue, defaultValue: defaultValue as! UInt64, min: minimum as? UInt64, max: maximum as? UInt64, stepSize: stepSize as? UInt64)
 		case .integer:
 			let clippedValue = clip(value as! Int, minimum as? Int, maximum as? Int)
 			self = .integer(value: clippedValue, defaultValue: defaultValue as! Int, min: minimum as? Int, max: maximum as? Int, stepSize: stepSize as? Int)
@@ -49,6 +81,22 @@ internal enum TweakViewData {
 			return boolValue
 		case let .integer(value: intValue, _, _, _, _):
 			return intValue
+		case let .int8(value: intValue, _, _, _, _):
+			return intValue
+		case let .int16(value: intValue, _, _, _, _):
+			return intValue
+		case let .int32(value: intValue, _, _, _, _):
+			return intValue
+		case let .int64(value: intValue, _, _, _, _):
+			return intValue
+		case let .uInt8(value: intValue, _, _, _, _):
+			return intValue
+		case let .uInt16(value: intValue, _, _, _, _):
+			return intValue
+		case let .uInt32(value: intValue, _, _, _, _):
+			return intValue
+		case let .uInt64(value: intValue, _, _, _, _):
+			return intValue
 		case let .float(value: floatValue, _, _, _, _):
 			return floatValue
 		case let .doubleTweak(value: doubleValue, _, _, _, _):
@@ -71,6 +119,22 @@ internal enum TweakViewData {
 			return nil
 		case let .integer(value: intValue, _, _, _, _):
 			return Double(intValue)
+		case let .int8(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .int16(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .int32(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .int64(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .uInt8(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .uInt16(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .uInt32(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .uInt64(value: intValue, _, _, _, _):
+			return Double(intValue)
 		case let .float(value: floatValue, _, _, _, _):
 			return Double(floatValue)
 		case let .doubleTweak(value: doubleValue, _, _, _, _):
@@ -87,6 +151,30 @@ internal enum TweakViewData {
 			differsFromDefault = (value != defaultValue)
 		case let .integer(value: value, defaultValue: defaultValue, _, _, _):
 			string = "Int(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .int8(value: value, defaultValue: defaultValue, _, _, _):
+			string = "Int8(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .int16(value: value, defaultValue: defaultValue, _, _, _):
+			string = "Int16(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .int32(value: value, defaultValue: defaultValue, _, _, _):
+			string = "Int32(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .int64(value: value, defaultValue: defaultValue, _, _, _):
+			string = "Int64(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .uInt8(value: value, defaultValue: defaultValue, _, _, _):
+			string = "UInt8(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .uInt16(value: value, defaultValue: defaultValue, _, _, _):
+			string = "UInt16(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .uInt32(value: value, defaultValue: defaultValue, _, _, _):
+			string = "UInt32(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .uInt64(value: value, defaultValue: defaultValue, _, _, _):
+			string = "UInt64(\(value))"
 			differsFromDefault = (value != defaultValue)
 		case let .float(value: value, defaultValue: defaultValue, _, _, _):
 			string = "Float(\(value))"
@@ -112,7 +200,7 @@ internal enum TweakViewData {
 
 	private var isSignedNumberType: Bool {
 		switch self {
-		case .integer, .float, .doubleTweak:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .float, .doubleTweak: // XXX not really signed?
 			return true
 		case .boolean, .color, .action, .string, .stringList:
 			return false
@@ -158,6 +246,70 @@ internal enum TweakViewData {
 			return nil
 
 		case let .integer(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .int8(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .int16(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .int32(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .int64(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .uInt8(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .uInt16(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .uInt32(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .uInt64(intValue, intDefaultValue, intMin, intMax, intStep):
 			currentValue = Double(intValue)
 			defaultValue = Double(intDefaultValue)
 			minimum = intMin.map(Double.init)

--- a/SwiftTweaks/TweakableType.swift
+++ b/SwiftTweaks/TweakableType.swift
@@ -21,6 +21,14 @@ public protocol TweakableType {
 public enum TweakViewDataType {
 	case boolean
 	case integer
+	case int8
+	case int16
+	case int32
+	case int64
+	case uInt8
+	case uInt16
+	case uInt32
+	case uInt64
 	case cgFloat
 	case double
 	case uiColor
@@ -29,7 +37,10 @@ public enum TweakViewDataType {
 	case action
 
 	public static let allTypes: [TweakViewDataType] = [
-		.boolean, .integer, .cgFloat, .action, .double, .uiColor, .string, .stringList, 
+		.boolean, .integer,
+		.int8, .int16, .int32, .int64,
+		.uInt8, .uInt16, .uInt32, .uInt64,
+		.cgFloat, .action, .double, .uiColor, .string, .stringList, 
 	]
 }
 
@@ -39,6 +50,14 @@ public enum TweakViewDataType {
 public enum TweakDefaultData {
 	case boolean(defaultValue: Bool)
 	case integer(defaultValue: Int, min: Int?, max: Int?, stepSize: Int?)
+	case int8(defaultValue: Int8, min: Int8?, max: Int8?, stepSize: Int8?)
+	case int16(defaultValue: Int16, min: Int16?, max: Int16?, stepSize: Int16?)
+	case int32(defaultValue: Int32, min: Int32?, max: Int32?, stepSize: Int32?)
+	case int64(defaultValue: Int64, min: Int64?, max: Int64?, stepSize: Int64?)
+	case uInt8(defaultValue: UInt8, min: UInt8?, max: UInt8?, stepSize: UInt8?)
+	case uInt16(defaultValue: UInt16, min: UInt16?, max: UInt16?, stepSize: UInt16?)
+	case uInt32(defaultValue: UInt32, min: UInt32?, max: UInt32?, stepSize: UInt32?)
+	case uInt64(defaultValue: UInt64, min: UInt64?, max: UInt64?, stepSize: UInt64?)
 	case float(defaultValue: CGFloat, min: CGFloat?, max: CGFloat?, stepSize: CGFloat?)
 	case doubleTweak(defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(defaultValue: UIColor)
@@ -78,6 +97,54 @@ extension Bool: TweakableType {
 extension Int: TweakableType {
 	public static var tweakViewDataType: TweakViewDataType {
 		return .integer
+	}
+}
+
+extension Int8: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .int8
+	}
+}
+
+extension Int16: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .int16
+	}
+}
+
+extension Int32: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .int32
+	}
+}
+
+extension Int64: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .int64
+	}
+}
+
+extension UInt8: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .uInt8
+	}
+}
+
+extension UInt16: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .uInt16
+	}
+}
+
+extension UInt32: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .uInt32
+	}
+}
+
+extension UInt64: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .uInt64
 	}
 }
 


### PR DESCRIPTION
This avoids having to cast the tweaked value into the desired type at runtime.

I work at Automatic Labs now (a hardware company), and having direct access to these low level types at compile time is very helpful.  Otherwise the code that uses the tweaked values needs to cast it at runtime to the desired type.  This can cause runtime crashes if people aren't careful.  Having the desired type pushed down into the tweaks prevents many of these failures from happening in the first place.