### PR TITLE
Make date type tweakable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Currently, you can tweak the following types:
 - [`TweakCallbacks`](#callbacks)
 - `String`
 - `StringOption`
+- `Date`
 
 A `Tweak` looks like this:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Currently, you can tweak the following types:
 
 - `Bool`
 - `Int`
+- `Int8`
+- `UInt8`
+- `Int16`
+- `UInt16`
+- `Int32`
+- `UInt32`
+- `Int64`
+- `UInt64`
 - `CGFloat`
 - `Double`
 - `UIColor`

--- a/SwiftTweaks/DatePickerViewController.swift
+++ b/SwiftTweaks/DatePickerViewController.swift
@@ -83,10 +83,6 @@ internal class DatePickerViewController: UIViewController {
         view.addSubview(dateLabel)
 
         view.backgroundColor = .white
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
 
         let labelHeight: CGFloat = 60
 

--- a/SwiftTweaks/DatePickerViewController.swift
+++ b/SwiftTweaks/DatePickerViewController.swift
@@ -1,0 +1,133 @@
+//
+//  DatePickerViewController.swift
+//  SwiftTweaks
+//
+//  Created by Brian Martin on 8/20/19.
+//
+
+import Foundation
+import UIKit
+
+internal protocol DatePickerViewControllerDelegate {
+	func datePickerViewControllerDidPressDismissButton(_ tweakSelectionViewController: DatePickerViewController)
+}
+
+/// Allows the user to select an option for a StringListOption value.
+internal class DatePickerViewController: UIViewController {
+	fileprivate let tweak: Tweak<Date>
+	fileprivate let tweakStore: TweakStore
+	fileprivate let delegate: DatePickerViewControllerDelegate
+    fileprivate let datePicker: UIDatePicker
+    fileprivate let dateLabel: UILabel
+	
+	fileprivate var currentOption: Date {
+		didSet {
+			tweakStore.setValue(
+				.date(
+					value: currentOption,
+					defaultValue: tweak.defaultValue
+				),
+				forTweak: AnyTweak(tweak: tweak)
+			)
+		}
+	}
+	
+	fileprivate static let cellIdentifier = "TweakSelectionViewControllerCellIdentifier"
+	
+    @objc func datePickerChanged(picker: UIDatePicker) {
+        dateLabel.text = "\(picker.date)" // XXX make this better
+        currentOption = picker.date
+    }
+
+    init(anyTweak: AnyTweak, tweakStore: TweakStore, delegate: DatePickerViewControllerDelegate) {
+		assert(anyTweak.tweakViewDataType == .date, "Can only choose a date value in this UI.")
+		
+		self.tweak = anyTweak.tweak as! Tweak<Date>
+		self.tweakStore = tweakStore
+		self.delegate = delegate
+		self.currentOption = tweakStore.currentValueForTweak(self.tweak)
+        self.datePicker = UIDatePicker()
+        self.dateLabel = UILabel()
+
+        super.init(nibName: nil, bundle: nil)
+
+        datePicker.datePickerMode = .dateAndTime
+        datePicker.addTarget(self,
+                             action: #selector(datePickerChanged(picker:)),
+                             for: .valueChanged)
+        datePicker.date = currentOption
+        dateLabel.text = "\(datePicker.date)" // XXX make this better
+        
+		title = tweak.tweakName
+		toolbarItems = [
+			UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+			UIBarButtonItem(title: TweaksViewController.dismissButtonTitle, style: .done, target: self, action: #selector(self.dismissButtonTapped))
+		]
+		
+		self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reset", style: .plain, target: self, action: #selector(DatePickerViewController.restoreDefaultValue))
+		self.navigationItem.rightBarButtonItem?.tintColor = AppTheme.Colors.controlDestructive
+	}
+	
+	required init?(coder aDecoder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+	
+    override func viewDidLoad() {
+        view.addSubview(datePicker)
+        view.addSubview(dateLabel)
+
+        view.backgroundColor = .white
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        var topUnsafeAreaSize: CGFloat = 0
+        
+        if #available(iOS 11.0, *) {
+            let safeLayout = view.safeAreaLayoutGuide
+            topUnsafeAreaSize = 80
+        } else {
+            if #available(iOS 9.0, *) {
+                let fuck = self.topLayoutGuide.heightAnchor
+            } else {
+                // Fallback on earlier versions
+            }
+            // Fallback on earlier versions
+        }
+
+        let labelHeight: CGFloat = 80
+
+        var realHeight = self.view.frame.height - 60
+        
+        let dateLabelFrame = CGRect(
+          origin: CGPoint(x: 0, y: realHeight-labelHeight),
+          size: CGSize(width: self.view.frame.width,
+                       height: labelHeight)
+        )
+        let datePickerFrame = CGRect(
+          origin: CGPoint(x: 0, y: 0),
+          size: CGSize(width: self.view.frame.width,
+                       height: realHeight-labelHeight)
+        )
+        datePicker.frame = datePickerFrame
+        dateLabel.frame = dateLabelFrame
+        dateLabel.textAlignment = .center
+    }
+    
+	// MARK: Events
+	
+	@objc private func dismissButtonTapped() {
+		delegate.datePickerViewControllerDidPressDismissButton(self)
+	}
+	
+	@objc private func restoreDefaultValue() {
+		let confirmationAlert = UIAlertController(title: "Reset This Tweak?", message: "Your other tweaks will be left alone. The default value is \(tweak.defaultValue)", preferredStyle: .actionSheet)
+		confirmationAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+		confirmationAlert.addAction(UIAlertAction(title: "Reset Tweak", style: .destructive, handler: { _ in
+			                                                                                       self.currentOption = self.tweak.defaultValue
+		}))
+		present(confirmationAlert, animated: true, completion: nil)
+	}
+}
+

--- a/SwiftTweaks/DatePickerViewController.swift
+++ b/SwiftTweaks/DatePickerViewController.swift
@@ -17,10 +17,10 @@ internal class DatePickerViewController: UIViewController {
 	fileprivate let tweak: Tweak<Date>
 	fileprivate let tweakStore: TweakStore
 	fileprivate let delegate: DatePickerViewControllerDelegate
-    fileprivate let datePicker: UIDatePicker
-    fileprivate let dateLabel: UILabel
-    fileprivate let dateFormatter = DateFormatter()
-    fileprivate let timeFormatter = DateFormatter()
+	fileprivate let datePicker: UIDatePicker
+	fileprivate let dateLabel: UILabel
+	fileprivate let dateFormatter = DateFormatter()
+	fileprivate let timeFormatter = DateFormatter()
 	
 	fileprivate var currentOption: Date {
 		didSet {

--- a/SwiftTweaks/DatePickerViewController.swift
+++ b/SwiftTweaks/DatePickerViewController.swift
@@ -19,6 +19,8 @@ internal class DatePickerViewController: UIViewController {
 	fileprivate let delegate: DatePickerViewControllerDelegate
     fileprivate let datePicker: UIDatePicker
     fileprivate let dateLabel: UILabel
+    fileprivate let dateFormatter = DateFormatter()
+    fileprivate let timeFormatter = DateFormatter()
 	
 	fileprivate var currentOption: Date {
 		didSet {
@@ -35,7 +37,7 @@ internal class DatePickerViewController: UIViewController {
 	fileprivate static let cellIdentifier = "TweakSelectionViewControllerCellIdentifier"
 	
     @objc func datePickerChanged(picker: UIDatePicker) {
-        dateLabel.text = "\(picker.date)" // XXX make this better
+        dateLabel.text = dateFormatter.string(from: datePicker.date) + "\n" + timeFormatter.string(from: datePicker.date)
         currentOption = picker.date
     }
 
@@ -51,12 +53,16 @@ internal class DatePickerViewController: UIViewController {
 
         super.init(nibName: nil, bundle: nil)
 
+        dateFormatter.dateStyle = .long
+        timeFormatter.timeStyle = .long
+        
         datePicker.datePickerMode = .dateAndTime
         datePicker.addTarget(self,
                              action: #selector(datePickerChanged(picker:)),
                              for: .valueChanged)
         datePicker.date = currentOption
-        dateLabel.text = "\(datePicker.date)" // XXX make this better
+        dateLabel.text = dateFormatter.string(from: datePicker.date) + "\n" + timeFormatter.string(from: datePicker.date)
+        dateLabel.numberOfLines = 2
         
 		title = tweak.tweakName
 		toolbarItems = [
@@ -82,37 +88,25 @@ internal class DatePickerViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        var topUnsafeAreaSize: CGFloat = 0
-        
-        if #available(iOS 11.0, *) {
-            let safeLayout = view.safeAreaLayoutGuide
-            topUnsafeAreaSize = 80
-        } else {
-            if #available(iOS 9.0, *) {
-                let fuck = self.topLayoutGuide.heightAnchor
-            } else {
-                // Fallback on earlier versions
-            }
-            // Fallback on earlier versions
-        }
+        let labelHeight: CGFloat = 60
 
-        let labelHeight: CGFloat = 80
+		datePicker.frame = CGRect(
+          origin: view.bounds.origin,
+          size: CGSize(
+            width: view.bounds.size.width,
+            height: view.bounds.size.height-labelHeight/2
+          )
+        )
+		datePicker.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
-        var realHeight = self.view.frame.height - 60
-        
-        let dateLabelFrame = CGRect(
-          origin: CGPoint(x: 0, y: realHeight-labelHeight),
+        dateLabel.frame = CGRect(
+          origin: CGPoint(x: 0, y: view.bounds.size.height-labelHeight-60),
           size: CGSize(width: self.view.frame.width,
                        height: labelHeight)
         )
-        let datePickerFrame = CGRect(
-          origin: CGPoint(x: 0, y: 0),
-          size: CGSize(width: self.view.frame.width,
-                       height: realHeight-labelHeight)
-        )
-        datePicker.frame = datePickerFrame
-        dateLabel.frame = dateLabelFrame
         dateLabel.textAlignment = .center
+        dateLabel.font = UIFont.systemFont(ofSize: 24)
+        dateLabel.adjustsFontSizeToFitWidth = true
     }
     
 	// MARK: Events

--- a/SwiftTweaks/FloatingTweakGroupViewController.swift
+++ b/SwiftTweaks/FloatingTweakGroupViewController.swift
@@ -33,7 +33,7 @@ internal final class FloatingTweakGroupViewController: UIViewController {
 		case .boolean, .integer, .int8, .int16, .int32, .int64,
              .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .double, .action:
 			return true
-		case .uiColor, .stringList, .string:
+		case .uiColor, .stringList, .string, .date:
 			return false
 		}
 	}
@@ -343,7 +343,7 @@ extension FloatingTweakGroupViewController: UITableViewDelegate {
 				actionTweak.defaultValue.evaluateAllClosures()
 			}
 		case .boolean, .cgFloat, .double, .integer, .int8, .int16, .int32, .int64,
-             .uInt8, .uInt16, .uInt32, .uInt64, .string, .stringList, .uiColor:
+             .uInt8, .uInt16, .uInt32, .uInt64, .string, .stringList, .uiColor, .date:
 			break
 		}
 		self.tableView.deselectRow(at: indexPath, animated: true)

--- a/SwiftTweaks/FloatingTweakGroupViewController.swift
+++ b/SwiftTweaks/FloatingTweakGroupViewController.swift
@@ -30,7 +30,8 @@ internal final class FloatingTweakGroupViewController: UIViewController {
 
 	static func editingSupported(forTweak tweak: AnyTweak) -> Bool {
 		switch tweak.tweakViewDataType {
-		case .boolean, .integer, .cgFloat, .double, .action:
+		case .boolean, .integer, .int8, .int16, .int32, .int64,
+             .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .double, .action:
 			return true
 		case .uiColor, .stringList, .string:
 			return false
@@ -341,7 +342,8 @@ extension FloatingTweakGroupViewController: UITableViewDelegate {
 			if let actionTweak = tweak.tweak as? Tweak<TweakAction> {            
 				actionTweak.defaultValue.evaluateAllClosures()
 			}
-		case .boolean, .cgFloat, .double, .integer, .string, .stringList, .uiColor:
+		case .boolean, .cgFloat, .double, .integer, .int8, .int16, .int32, .int64,
+             .uInt8, .uInt16, .uInt32, .uInt64, .string, .stringList, .uiColor:
 			break
 		}
 		self.tableView.deselectRow(at: indexPath, animated: true)

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -136,6 +136,62 @@ extension Tweak: TweakType {
 				max: maximumValue as? Int,
 				stepSize: stepSize as? Int
 			)
+		case .int8:
+			return .int8(
+				defaultValue: defaultValue as! Int8,
+				min: minimumValue as? Int8,
+				max: maximumValue as? Int8,
+				stepSize: stepSize as? Int8
+			)
+		case .int16:
+			return .int16(
+				defaultValue: defaultValue as! Int16,
+				min: minimumValue as? Int16,
+				max: maximumValue as? Int16,
+				stepSize: stepSize as? Int16
+			)
+		case .int32:
+			return .int32(
+				defaultValue: defaultValue as! Int32,
+				min: minimumValue as? Int32,
+				max: maximumValue as? Int32,
+				stepSize: stepSize as? Int32
+			)
+		case .int64:
+			return .int64(
+				defaultValue: defaultValue as! Int64,
+				min: minimumValue as? Int64,
+				max: maximumValue as? Int64,
+				stepSize: stepSize as? Int64
+			)
+		case .uInt8:
+			return .uInt8(
+				defaultValue: defaultValue as! UInt8,
+				min: minimumValue as? UInt8,
+				max: maximumValue as? UInt8,
+				stepSize: stepSize as? UInt8
+			)
+		case .uInt16:
+			return .uInt16(
+				defaultValue: defaultValue as! UInt16,
+				min: minimumValue as? UInt16,
+				max: maximumValue as? UInt16,
+				stepSize: stepSize as? UInt16
+			)
+		case .uInt32:
+			return .uInt32(
+				defaultValue: defaultValue as! UInt32,
+				min: minimumValue as? UInt32,
+				max: maximumValue as? UInt32,
+				stepSize: stepSize as? UInt32
+			)
+		case .uInt64:
+			return .uInt64(
+				defaultValue: defaultValue as! UInt64,
+				min: minimumValue as? UInt64,
+				max: maximumValue as? UInt64,
+				stepSize: stepSize as? UInt64
+			)
 		case .cgFloat:
 			return .float(
 				defaultValue: defaultValue as! CGFloat,

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -210,6 +210,8 @@ extension Tweak: TweakType {
 			return .color(defaultValue: defaultValue as! UIColor)
 		case .string:
 			return .string(defaultValue: defaultValue as! String)
+		case .date:
+			return .date(defaultValue: defaultValue as! Date)
 		case .stringList:
 			return .stringList(
 				defaultValue: defaultValue as! StringOption,

--- a/SwiftTweaks/TweakBinding.swift
+++ b/SwiftTweaks/TweakBinding.swift
@@ -21,7 +21,7 @@ internal struct TweakBinding<T: TweakableType>: TweakBindingType{
 
 	func applyBindingWithValue(_ value: TweakableType) {
 		switch type(of: value).tweakViewDataType {
-		case .boolean, .integer, .cgFloat, .action, .double, .uiColor, .string, .stringList:
+		case .boolean, .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .action, .double, .uiColor, .string, .stringList:
 			binding(value as! T)
 		}
 	}

--- a/SwiftTweaks/TweakBinding.swift
+++ b/SwiftTweaks/TweakBinding.swift
@@ -21,7 +21,7 @@ internal struct TweakBinding<T: TweakableType>: TweakBindingType{
 
 	func applyBindingWithValue(_ value: TweakableType) {
 		switch type(of: value).tweakViewDataType {
-		case .boolean, .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .action, .double, .uiColor, .string, .stringList:
+		case .boolean, .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .action, .double, .uiColor, .string, .stringList, .date:
 			binding(value as! T)
 		}
 	}

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -138,7 +138,7 @@ extension TweakCollectionViewController: UITableViewDelegate {
 			let actionTweak = tweak.tweak as! Tweak<TweakAction>
 			actionTweak.defaultValue.evaluateAllClosures()
 			self.hapticsPlayer.playNotificationSuccess()
-		case .integer, .cgFloat, .double, .string:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .double, .string:
 			let cell = tableView.cellForRow(at: indexPath) as! TweakTableCell
 			cell.startEditingTextField()
 		case .boolean:

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -141,6 +141,9 @@ extension TweakCollectionViewController: UITableViewDelegate {
 		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .cgFloat, .double, .string:
 			let cell = tableView.cellForRow(at: indexPath) as! TweakTableCell
 			cell.startEditingTextField()
+        case .date:
+			let datePickerVC = DatePickerViewController(anyTweak: tweak, tweakStore: self.tweakStore, delegate: self)
+			self.navigationController?.pushViewController(datePickerVC, animated: true)
 		case .boolean:
 			break
 		}
@@ -212,6 +215,12 @@ extension TweakCollectionViewController: TweakColorEditViewControllerDelegate {
 
 extension TweakCollectionViewController: StringOptionViewControllerDelegate {
 	func stringOptionViewControllerDidPressDismissButton(_ tweakSelectionViewController: StringOptionViewController) {
+		self.delegate.tweakCollectionViewControllerDidPressDismissButton(self)
+	}
+}
+
+extension TweakCollectionViewController: DatePickerViewControllerDelegate {
+	func datePickerViewControllerDidPressDismissButton(_ tweakSelectionViewController: DatePickerViewController) {
 		self.delegate.tweakCollectionViewControllerDidPressDismissButton(self)
 	}
 }

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -181,6 +181,7 @@ private final class TweakDiskPersistency {
 			case .double: return anyObject as? Double
 			case .uiColor: return anyObject as? UIColor
 			case .string: return anyObject as? String
+			case .date: return anyObject as? Date
 			case .stringList:
 				guard let stringOptionString = anyObject as? String else {
 					return nil
@@ -212,6 +213,7 @@ private extension TweakViewDataType {
 		case .string: return "string"
 		case .stringList: return "stringlist"
 		case .action: return "action"
+		case .date: return "date"
 		}
 	}
 }
@@ -234,6 +236,7 @@ private extension TweakableType {
 			case .double: return self as! Double as AnyObject
 			case .uiColor: return self as! UIColor
 			case .string: return self as! NSString
+			case .date: return self as! NSDate
 			case .stringList: return (self as! StringOption).value as AnyObject
 			case .action: return true as AnyObject
 		}

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -168,6 +168,14 @@ private final class TweakDiskPersistency {
 		private static func tweakableTypeWithAnyObject(_ anyObject: AnyObject, withType type: TweakViewDataType) -> TweakableType? {
 			switch type {
 			case .integer: return anyObject as? Int
+			case .int8: return anyObject as? Int8
+			case .int16: return anyObject as? Int16
+			case .int32: return anyObject as? Int32
+			case .int64: return anyObject as? Int64
+			case .uInt8: return anyObject as? UInt8
+			case .uInt16: return anyObject as? UInt16
+			case .uInt32: return anyObject as? UInt32
+			case .uInt64: return anyObject as? UInt64
 			case .boolean: return anyObject as? Bool
 			case .cgFloat: return anyObject as? CGFloat
 			case .double: return anyObject as? Double
@@ -190,6 +198,14 @@ private extension TweakViewDataType {
 		switch self {
 		case .boolean: return "boolean"
 		case .integer: return "integer"
+		case .int8: return "int8"
+		case .int16: return "int16"
+		case .int32: return "int32"
+		case .int64: return "int64"
+		case .uInt8: return "uInt8"
+		case .uInt16: return "uInt16"
+		case .uInt32: return "uInt32"
+		case .uInt64: return "uInt64"
 		case .cgFloat: return "cgfloat"
 		case .double: return "double"
 		case .uiColor: return "uicolor"
@@ -206,6 +222,14 @@ private extension TweakableType {
 		switch type(of: self).tweakViewDataType {
 			case .boolean: return self as! Bool as AnyObject
 			case .integer: return self as! Int as AnyObject
+			case .int8: return self as! Int8 as AnyObject
+			case .int16: return self as! Int16 as AnyObject
+			case .int32: return self as! Int32 as AnyObject
+			case .int64: return self as! Int64 as AnyObject
+			case .uInt8: return self as! UInt8 as AnyObject
+			case .uInt16: return self as! UInt16 as AnyObject
+			case .uInt32: return self as! UInt32 as AnyObject
+			case .uInt64: return self as! UInt64 as AnyObject
 			case .cgFloat: return self as! CGFloat as AnyObject
 			case .double: return self as! Double as AnyObject
 			case .uiColor: return self as! UIColor

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -186,6 +186,9 @@ public final class TweakStore {
 		case let .action(defaultValue: defaultValue):
 			let currentValue = cachedValue as? TweakAction ?? defaultValue
 			return .action(value: currentValue)
+		case let .date(defaultValue):
+			let currentValue = cachedValue as? Date ?? defaultValue
+			return .date(value: currentValue, defaultValue: defaultValue)
 		}
 	}
 	

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -144,6 +144,30 @@ public final class TweakStore {
 		case let .integer(defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			let currentValue = cachedValue as? Int ?? defaultValue
 			return .integer(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .int8(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? Int8 ?? defaultValue
+			return .int8(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .int16(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? Int16 ?? defaultValue
+			return .int16(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .int32(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? Int32 ?? defaultValue
+			return .int32(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .int64(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? Int64 ?? defaultValue
+			return .int64(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .uInt8(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? UInt8 ?? defaultValue
+			return .uInt8(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .uInt16(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? UInt16 ?? defaultValue
+			return .uInt16(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .uInt32(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? UInt32 ?? defaultValue
+			return .uInt32(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
+		case let .uInt64(defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			let currentValue = cachedValue as? UInt64 ?? defaultValue
+			return .uInt64(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)
 		case let .float(defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			let currentValue = cachedValue as? CGFloat ?? defaultValue
 			return .float(value: currentValue, defaultValue: defaultValue, min: min, max: max, stepSize: step)

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -328,7 +328,10 @@ internal final class TweakTableCell: UITableViewCell {
 			textFieldEnabled = true
 
 		case let .date(value, _):
-			textField.text = "\(value)" // XXX fix this
+			let dateFormatter = DateFormatter()
+			dateFormatter.dateStyle = .short
+			dateFormatter.timeStyle = .short
+			textField.text = dateFormatter.string(from: value)
 
 			textFieldEnabled = false
 

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -31,7 +31,7 @@ internal final class TweakTableCell: UITableViewCell {
 	internal var isInFloatingTweakGroupWindow = false
 
 	private var accessory = UIView()
-
+    
 	private let switchControl: UISwitch = {
 		let switchControl = UISwitch()
 		switchControl.onTintColor = AppTheme.Colors.controlTinted
@@ -76,7 +76,7 @@ internal final class TweakTableCell: UITableViewCell {
 		textField.delegate = self
 
 		detailTextLabel!.textColor = AppTheme.Colors.textPrimary
-
+        
 		let touchHighlightView = UIView()
 		touchHighlightView.backgroundColor = AppTheme.Colors.tableCellTouchHighlight
 		self.selectedBackgroundView = touchHighlightView
@@ -109,7 +109,7 @@ internal final class TweakTableCell: UITableViewCell {
 			switchControl.sizeToFit()
 			accessory.bounds = switchControl.bounds
 
-		case .integer, .float, .doubleTweak:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .float, .doubleTweak:
 			stepperControl.sizeToFit()
 
 			let textFrame = CGRect(
@@ -222,7 +222,7 @@ internal final class TweakTableCell: UITableViewCell {
 			colorChit.isHidden = true
 			disclosureArrow.isHidden = true
 			selectionStyle = .none
-		case .integer, .float, .doubleTweak:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .float, .doubleTweak:
 			switchControl.isHidden = true
 			textField.isHidden = false
 			stepperControl.isHidden = false
@@ -276,7 +276,7 @@ internal final class TweakTableCell: UITableViewCell {
 			switchControl.isOn = value
 			textFieldEnabled = false
 
-		case .integer:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64:
 			let doubleValue = viewData.doubleValue!
 			self.updateStepper(value: doubleValue, stepperValues: viewData.stepperValues!)
 
@@ -347,6 +347,30 @@ internal final class TweakTableCell: UITableViewCell {
 		case let .integer(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			viewData = TweakViewData(type: .integer, value: Int(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
 			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .int8(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .int8, value: Int8(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .int16(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .int16, value: Int16(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .int32(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .int32, value: Int32(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .int64(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .int64, value: Int64(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .uInt8(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .uInt8, value: UInt8(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .uInt16(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .uInt16, value: UInt16(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .uInt32(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .uInt32, value: UInt32(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
+		case let .uInt64(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
+			viewData = TweakViewData(type: .uInt64, value: UInt64(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
+			delegate?.tweakCellDidChangeCurrentValue(self)
 		case let .float(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			viewData = TweakViewData(type: .cgFloat, value: CGFloat(stepperControl.value), defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
 			delegate?.tweakCellDidChangeCurrentValue(self)
@@ -374,6 +398,62 @@ extension TweakTableCell: UITextFieldDelegate {
 		case let .integer(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
 			if let text = textField.text, let newValue = Int(text) {
 				viewData = TweakViewData(type: .integer, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .int8(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = Int8(text) {
+				viewData = TweakViewData(type: .int8, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .int16(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = Int16(text) {
+				viewData = TweakViewData(type: .int16, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .int32(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = Int32(text) {
+				viewData = TweakViewData(type: .int32, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .int64(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = Int64(text) {
+				viewData = TweakViewData(type: .int64, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .uInt8(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = UInt8(text) {
+				viewData = TweakViewData(type: .uInt8, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .uInt16(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = UInt16(text) {
+				viewData = TweakViewData(type: .uInt16, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .uInt32(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = UInt32(text) {
+				viewData = TweakViewData(type: .uInt32, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
+				delegate?.tweakCellDidChangeCurrentValue(self)
+			} else {
+				updateSubviews()
+			}
+		case let .uInt64(_, defaultValue: defaultValue, min: minimum, max: maximum, stepSize: step):
+			if let text = textField.text, let newValue = UInt64(text) {
+				viewData = TweakViewData(type: .uInt64, value: newValue, defaultValue: defaultValue, minimum: minimum, maximum: maximum, stepSize: step, options: nil)
 				delegate?.tweakCellDidChangeCurrentValue(self)
 			} else {
 				updateSubviews()

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -163,7 +163,7 @@ internal final class TweakTableCell: UITableViewCell {
 
 			textField.frame = textFrame
 			colorChit.frame = colorControlFrame
-			disclosureArrow.frame = disclosureArrowFrame
+ 			disclosureArrow.frame = disclosureArrowFrame
 
 			let accessoryFrame = colorControlFrame.union(textFrame).union(disclosureArrowFrame)
 			accessory.bounds = accessoryFrame.integral
@@ -178,6 +178,23 @@ internal final class TweakTableCell: UITableViewCell {
 			).integral
 			textField.frame = textFrame
 			accessory.bounds = textField.bounds
+
+		case .date:
+			let textFieldFrame = CGRect(
+				origin: .zero,
+				size: CGSize(
+					width: bounds.width * TweakTableCell.stringTextWidthFraction,
+					height: bounds.height
+				)
+			).integral
+			textField.frame = textFieldFrame
+			accessory.bounds = textField.bounds
+			let disclosureArrowFrame = CGRect(
+				origin: CGPoint(x: textFieldFrame.width + TweakTableCell.horizontalPadding, y: 0),
+				size: CGSize(width: disclosureArrow.bounds.width, height: bounds.height)
+			)
+			disclosureArrow.frame = disclosureArrowFrame
+			accessory.bounds = textFieldFrame.union(disclosureArrowFrame).integral
 
 		case .stringList:
 			let textFieldFrame = CGRect(
@@ -243,6 +260,13 @@ internal final class TweakTableCell: UITableViewCell {
 			colorChit.isHidden = true
 			disclosureArrow.isHidden = true
 			selectionStyle = .default
+		case .date:
+			switchControl.isHidden = true
+			textField.isHidden = false
+			stepperControl.isHidden = true
+			colorChit.isHidden = true
+			disclosureArrow.isHidden = false
+			selectionStyle = .default
 		case .action:
 			switchControl.isHidden = true
 			textField.isHidden = true
@@ -302,6 +326,11 @@ internal final class TweakTableCell: UITableViewCell {
 			textField.placeholder = NSLocalizedString("Tap to edit", comment: "Text field placeholder for editable text")
 			textField.keyboardType = .default
 			textFieldEnabled = true
+
+		case let .date(value, _):
+			textField.text = "\(value)" // XXX fix this
+
+			textFieldEnabled = false
 
 		case let .stringList(value: value, _, options: _):
 			textField.text = value.value
@@ -377,7 +406,7 @@ internal final class TweakTableCell: UITableViewCell {
 		case let .doubleTweak(_, defaultValue: defaultValue, min: min, max: max, stepSize: step):
 			viewData = TweakViewData(type: .double, value: stepperControl.value, defaultValue: defaultValue, minimum: min, maximum: max, stepSize: step, options: nil)
 			delegate?.tweakCellDidChangeCurrentValue(self)
-		case .color, .boolean, .action, .stringList, .string:
+		case .color, .boolean, .action, .stringList, .string, .date:
 			assertionFailure("Shouldn't be able to update text field with a Color/Boolean/Action/StringList/String tweak.")
 		}
 	}
@@ -486,7 +515,7 @@ extension TweakTableCell: UITextFieldDelegate {
 			} else {
 				updateSubviews()
 			}
-		case .boolean, .action, .stringList:
+		case .boolean, .action, .stringList, .date:
 			assertionFailure("Shouldn't be able to update text field with a Boolean/Action/StringList tweak.")
 		}
 	}

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -12,6 +12,14 @@ import UIKit
 internal enum TweakViewData {
 	case boolean(value: Bool, defaultValue: Bool)
 	case integer(value: Int, defaultValue: Int, min: Int?, max: Int?, stepSize: Int?)
+	case int8(value: Int8, defaultValue: Int8, min: Int8?, max: Int8?, stepSize: Int8?)
+	case int16(value: Int16, defaultValue: Int16, min: Int16?, max: Int16?, stepSize: Int16?)
+	case int32(value: Int32, defaultValue: Int32, min: Int32?, max: Int32?, stepSize: Int32?)
+	case int64(value: Int64, defaultValue: Int64, min: Int64?, max: Int64?, stepSize: Int64?)
+	case uInt8(value: UInt8, defaultValue: UInt8, min: UInt8?, max: UInt8?, stepSize: UInt8?)
+	case uInt16(value: UInt16, defaultValue: UInt16, min: UInt16?, max: UInt16?, stepSize: UInt16?)
+	case uInt32(value: UInt32, defaultValue: UInt32, min: UInt32?, max: UInt32?, stepSize: UInt32?)
+	case uInt64(value: UInt64, defaultValue: UInt64, min: UInt64?, max: UInt64?, stepSize: UInt64?)
 	case float(value: CGFloat, defaultValue: CGFloat, min: CGFloat?, max: CGFloat?, stepSize: CGFloat?)
 	case doubleTweak(value: Double, defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(value: UIColor, defaultValue: UIColor)
@@ -25,6 +33,30 @@ internal enum TweakViewData {
 			self = .boolean(value: value as! Bool, defaultValue: defaultValue as! Bool)
 		case .uiColor:
 			self = .color(value: value as! UIColor, defaultValue: defaultValue as! UIColor)
+		case .int8:
+			let clippedValue = clip(value as! Int8, minimum as? Int8, maximum as? Int8)
+			self = .int8(value: clippedValue, defaultValue: defaultValue as! Int8, min: minimum as? Int8, max: maximum as? Int8, stepSize: stepSize as? Int8)
+		case .int16:
+			let clippedValue = clip(value as! Int16, minimum as? Int16, maximum as? Int16)
+			self = .int16(value: clippedValue, defaultValue: defaultValue as! Int16, min: minimum as? Int16, max: maximum as? Int16, stepSize: stepSize as? Int16)
+		case .int32:
+			let clippedValue = clip(value as! Int32, minimum as? Int32, maximum as? Int32)
+			self = .int32(value: clippedValue, defaultValue: defaultValue as! Int32, min: minimum as? Int32, max: maximum as? Int32, stepSize: stepSize as? Int32)
+		case .int64:
+			let clippedValue = clip(value as! Int64, minimum as? Int64, maximum as? Int64)
+			self = .int64(value: clippedValue, defaultValue: defaultValue as! Int64, min: minimum as? Int64, max: maximum as? Int64, stepSize: stepSize as? Int64)
+		case .uInt8:
+			let clippedValue = clip(value as! UInt8, minimum as? UInt8, maximum as? UInt8)
+			self = .uInt8(value: clippedValue, defaultValue: defaultValue as! UInt8, min: minimum as? UInt8, max: maximum as? UInt8, stepSize: stepSize as? UInt8)
+		case .uInt16:
+			let clippedValue = clip(value as! UInt16, minimum as? UInt16, maximum as? UInt16)
+			self = .uInt16(value: clippedValue, defaultValue: defaultValue as! UInt16, min: minimum as? UInt16, max: maximum as? UInt16, stepSize: stepSize as? UInt16)
+		case .uInt32:
+			let clippedValue = clip(value as! UInt32, minimum as? UInt32, maximum as? UInt32)
+			self = .uInt32(value: clippedValue, defaultValue: defaultValue as! UInt32, min: minimum as? UInt32, max: maximum as? UInt32, stepSize: stepSize as? UInt32)
+		case .uInt64:
+			let clippedValue = clip(value as! UInt64, minimum as? UInt64, maximum as? UInt64)
+			self = .uInt64(value: clippedValue, defaultValue: defaultValue as! UInt64, min: minimum as? UInt64, max: maximum as? UInt64, stepSize: stepSize as? UInt64)
 		case .integer:
 			let clippedValue = clip(value as! Int, minimum as? Int, maximum as? Int)
 			self = .integer(value: clippedValue, defaultValue: defaultValue as! Int, min: minimum as? Int, max: maximum as? Int, stepSize: stepSize as? Int)
@@ -49,6 +81,22 @@ internal enum TweakViewData {
 			return boolValue
 		case let .integer(value: intValue, _, _, _, _):
 			return intValue
+		case let .int8(value: intValue, _, _, _, _):
+			return intValue
+		case let .int16(value: intValue, _, _, _, _):
+			return intValue
+		case let .int32(value: intValue, _, _, _, _):
+			return intValue
+		case let .int64(value: intValue, _, _, _, _):
+			return intValue
+		case let .uInt8(value: intValue, _, _, _, _):
+			return intValue
+		case let .uInt16(value: intValue, _, _, _, _):
+			return intValue
+		case let .uInt32(value: intValue, _, _, _, _):
+			return intValue
+		case let .uInt64(value: intValue, _, _, _, _):
+			return intValue
 		case let .float(value: floatValue, _, _, _, _):
 			return floatValue
 		case let .doubleTweak(value: doubleValue, _, _, _, _):
@@ -71,6 +119,22 @@ internal enum TweakViewData {
 			return nil
 		case let .integer(value: intValue, _, _, _, _):
 			return Double(intValue)
+		case let .int8(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .int16(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .int32(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .int64(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .uInt8(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .uInt16(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .uInt32(value: intValue, _, _, _, _):
+			return Double(intValue)
+		case let .uInt64(value: intValue, _, _, _, _):
+			return Double(intValue)
 		case let .float(value: floatValue, _, _, _, _):
 			return Double(floatValue)
 		case let .doubleTweak(value: doubleValue, _, _, _, _):
@@ -87,6 +151,30 @@ internal enum TweakViewData {
 			differsFromDefault = (value != defaultValue)
 		case let .integer(value: value, defaultValue: defaultValue, _, _, _):
 			string = "Int(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .int8(value: value, defaultValue: defaultValue, _, _, _):
+			string = "Int8(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .int16(value: value, defaultValue: defaultValue, _, _, _):
+			string = "Int16(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .int32(value: value, defaultValue: defaultValue, _, _, _):
+			string = "Int32(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .int64(value: value, defaultValue: defaultValue, _, _, _):
+			string = "Int64(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .uInt8(value: value, defaultValue: defaultValue, _, _, _):
+			string = "UInt8(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .uInt16(value: value, defaultValue: defaultValue, _, _, _):
+			string = "UInt16(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .uInt32(value: value, defaultValue: defaultValue, _, _, _):
+			string = "UInt32(\(value))"
+			differsFromDefault = (value != defaultValue)
+		case let .uInt64(value: value, defaultValue: defaultValue, _, _, _):
+			string = "UInt64(\(value))"
 			differsFromDefault = (value != defaultValue)
 		case let .float(value: value, defaultValue: defaultValue, _, _, _):
 			string = "Float(\(value))"
@@ -112,7 +200,7 @@ internal enum TweakViewData {
 
 	private var isSignedNumberType: Bool {
 		switch self {
-		case .integer, .float, .doubleTweak:
+		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .float, .doubleTweak: // XXX not really signed?
 			return true
 		case .boolean, .color, .action, .string, .stringList:
 			return false
@@ -158,6 +246,70 @@ internal enum TweakViewData {
 			return nil
 
 		case let .integer(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .int8(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .int16(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .int32(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .int64(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .uInt8(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .uInt16(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .uInt32(intValue, intDefaultValue, intMin, intMax, intStep):
+			currentValue = Double(intValue)
+			defaultValue = Double(intDefaultValue)
+			minimum = intMin.map(Double.init)
+			maximum = intMax.map(Double.init)
+			step = intStep.map(Double.init)
+			isInteger = true
+
+		case let .uInt64(intValue, intDefaultValue, intMin, intMax, intStep):
 			currentValue = Double(intValue)
 			defaultValue = Double(intDefaultValue)
 			minimum = intMin.map(Double.init)

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -24,6 +24,7 @@ internal enum TweakViewData {
 	case doubleTweak(value: Double, defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(value: UIColor, defaultValue: UIColor)
 	case string(value: String, defaultValue: String)
+	case date(value: Date, defaultValue: Date)
 	case stringList(value: StringOption, defaultValue: StringOption, options: [StringOption])
 	case action(value: TweakAction)
 
@@ -68,6 +69,8 @@ internal enum TweakViewData {
 			self = .doubleTweak(value: clippedValue, defaultValue: defaultValue as! Double, min: minimum as? Double, max: maximum as? Double, stepSize: stepSize as? Double)
 		case .string:
 			self = .string(value: value as! String, defaultValue: defaultValue as! String)
+		case .date:
+			self = .date(value: value as! Date, defaultValue: defaultValue as! Date)
 		case .stringList:
 			self = .stringList(value: value as! StringOption, defaultValue: defaultValue as! StringOption, options: options!.map { $0 as! StringOption })
 		case .action:
@@ -103,6 +106,8 @@ internal enum TweakViewData {
 			return doubleValue
 		case let .color(value: colorValue, defaultValue: _):
 			return colorValue
+		case let .date(dateValue, _):
+			return dateValue
 		case let .string(stringValue, _):
 			return stringValue
 		case let .stringList(value: stringValue, _, _):
@@ -115,7 +120,7 @@ internal enum TweakViewData {
 	/// For signedNumberType tweaks, this is a shortcut to `value` as a Double
 	var doubleValue: Double? {
 		switch self {
-		case .boolean, .color, .action, .string, .stringList:
+		case .boolean, .color, .action, .string, .stringList, .date:
 			return nil
 		case let .integer(value: intValue, _, _, _, _):
 			return Double(intValue)
@@ -188,6 +193,9 @@ internal enum TweakViewData {
 		case let .string(value, defaultValue):
 			string = value
 			differsFromDefault = (value != defaultValue)
+		case let .date(value, defaultValue):
+			string = "\(value)"
+			differsFromDefault = (value != defaultValue)
 		case let .stringList(value: value, defaultValue: defaultValue, _):
 			string = value.value
 			differsFromDefault = string != defaultValue.value
@@ -202,7 +210,7 @@ internal enum TweakViewData {
 		switch self {
 		case .integer, .int8, .int16, .int32, .int64, .uInt8, .uInt16, .uInt32, .uInt64, .float, .doubleTweak: // XXX not really signed?
 			return true
-		case .boolean, .color, .action, .string, .stringList:
+		case .boolean, .color, .action, .string, .stringList, .date:
 			return false
 		}
 	}
@@ -242,7 +250,7 @@ internal enum TweakViewData {
 		let step: Double?
 		let isInteger: Bool
 		switch self {
-		case .boolean, .color, .action, .stringList, .string:
+		case .boolean, .color, .action, .stringList, .string, .date:
 			return nil
 
 		case let .integer(intValue, intDefaultValue, intMin, intMax, intStep):

--- a/SwiftTweaks/TweakableType.swift
+++ b/SwiftTweaks/TweakableType.swift
@@ -35,12 +35,13 @@ public enum TweakViewDataType {
 	case string
 	case stringList
 	case action
+	case date
 
 	public static let allTypes: [TweakViewDataType] = [
 		.boolean, .integer,
 		.int8, .int16, .int32, .int64,
 		.uInt8, .uInt16, .uInt32, .uInt64,
-		.cgFloat, .action, .double, .uiColor, .string, .stringList, 
+		.cgFloat, .action, .double, .uiColor, .string, .stringList, .date
 	]
 }
 
@@ -64,6 +65,7 @@ public enum TweakDefaultData {
 	case string(defaultValue: String)
 	case stringList(defaultValue: StringOption, options: [StringOption])
 	case action(defaultValue: TweakAction)
+	case date(defaultValue: Date)
 }
 
 // MARK: Types that conform to TweakableType
@@ -169,5 +171,11 @@ extension UIColor: TweakableType {
 extension String: TweakableType {
 	public static var tweakViewDataType: TweakViewDataType {
 		return .string
+	}
+}
+
+extension Date: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .date
 	}
 }

--- a/SwiftTweaks/TweakableType.swift
+++ b/SwiftTweaks/TweakableType.swift
@@ -21,6 +21,14 @@ public protocol TweakableType {
 public enum TweakViewDataType {
 	case boolean
 	case integer
+	case int8
+	case int16
+	case int32
+	case int64
+	case uInt8
+	case uInt16
+	case uInt32
+	case uInt64
 	case cgFloat
 	case double
 	case uiColor
@@ -29,7 +37,10 @@ public enum TweakViewDataType {
 	case action
 
 	public static let allTypes: [TweakViewDataType] = [
-		.boolean, .integer, .cgFloat, .action, .double, .uiColor, .string, .stringList, 
+		.boolean, .integer,
+		.int8, .int16, .int32, .int64,
+		.uInt8, .uInt16, .uInt32, .uInt64,
+		.cgFloat, .action, .double, .uiColor, .string, .stringList, 
 	]
 }
 
@@ -39,6 +50,14 @@ public enum TweakViewDataType {
 public enum TweakDefaultData {
 	case boolean(defaultValue: Bool)
 	case integer(defaultValue: Int, min: Int?, max: Int?, stepSize: Int?)
+	case int8(defaultValue: Int8, min: Int8?, max: Int8?, stepSize: Int8?)
+	case int16(defaultValue: Int16, min: Int16?, max: Int16?, stepSize: Int16?)
+	case int32(defaultValue: Int32, min: Int32?, max: Int32?, stepSize: Int32?)
+	case int64(defaultValue: Int64, min: Int64?, max: Int64?, stepSize: Int64?)
+	case uInt8(defaultValue: UInt8, min: UInt8?, max: UInt8?, stepSize: UInt8?)
+	case uInt16(defaultValue: UInt16, min: UInt16?, max: UInt16?, stepSize: UInt16?)
+	case uInt32(defaultValue: UInt32, min: UInt32?, max: UInt32?, stepSize: UInt32?)
+	case uInt64(defaultValue: UInt64, min: UInt64?, max: UInt64?, stepSize: UInt64?)
 	case float(defaultValue: CGFloat, min: CGFloat?, max: CGFloat?, stepSize: CGFloat?)
 	case doubleTweak(defaultValue: Double, min: Double?, max: Double?, stepSize: Double?)
 	case color(defaultValue: UIColor)
@@ -78,6 +97,54 @@ extension Bool: TweakableType {
 extension Int: TweakableType {
 	public static var tweakViewDataType: TweakViewDataType {
 		return .integer
+	}
+}
+
+extension Int8: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .int8
+	}
+}
+
+extension Int16: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .int16
+	}
+}
+
+extension Int32: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .int32
+	}
+}
+
+extension Int64: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .int64
+	}
+}
+
+extension UInt8: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .uInt8
+	}
+}
+
+extension UInt16: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .uInt16
+	}
+}
+
+extension UInt32: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .uInt32
+	}
+}
+
+extension UInt64: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .uInt64
 	}
 }
 


### PR DESCRIPTION
This is based upon my previous PR from yesterday, which represents all Int8-64 and UInt8-64 types as TweakableType.  I thought about separating this out, but the number of conflicts I would have gotten trying to merge them back together kept me from doing so.

What is added here is now the Date type is also a TweakableType.  Added is a new DatePickerViewController, which is shown to the user when selecting the correct date.  Dates are represented in the current locale for choosing, and the timezone is properly shown by the date formatter's long time format down below to make things as clear as possible.

Also @bryanjclark if you need some help reviewing PR's here, let me know. 