### PR TITLE
Adding support for static library and xcframeworks

### DIFF
--- a/SwiftTweaks.podspec
+++ b/SwiftTweaks.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/Khan/SwiftTweaks.git", :tag => "v4.1.2", :submodules => true }
   s.source_files = "SwiftTweaks/**/*.swift"
-  s.resources = "SwiftTweaks/*.xcassets"
+  s.resource_bundles = { 'SwiftTweaks' => ['SwiftTweaks/Media.xcassets/**/*'] }
 
   s.swift_version = "5.0"
   


### PR DESCRIPTION
Use "resource_bundle" instead of "resources" in podspec for allowing build the app with static framework linking