### PR TITLE
Fix deprecated 'class' keyword

### DIFF
--- a/SwiftTweaks/StringOptionViewController.swift
+++ b/SwiftTweaks/StringOptionViewController.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-internal protocol StringOptionViewControllerDelegate: class {
+internal protocol StringOptionViewControllerDelegate: AnyObject {
 	func stringOptionViewControllerDidPressDismissButton(_ tweakSelectionViewController: StringOptionViewController)
 }
 

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal protocol TweakCollectionViewControllerDelegate: class {
+internal protocol TweakCollectionViewControllerDelegate: AnyObject {
 	func tweakCollectionViewControllerDidPressDismissButton(_ tweakCollectionViewController: TweakCollectionViewController)
 	func tweakCollectionViewController(_ tweakCollectionViewController: TweakCollectionViewController, didTapFloatingTweakGroupButtonForTweakGroup tweakGroup: TweakGroup)
 }
@@ -224,7 +224,7 @@ extension TweakCollectionViewController: TweakGroupSectionHeaderDelegate {
 	}
 }
 
-private protocol TweakGroupSectionHeaderDelegate: class {
+private protocol TweakGroupSectionHeaderDelegate: AnyObject {
 	func tweakGroupSectionHeaderDidPressFloatingButton(_ sectionHeader: TweakGroupSectionHeader)
 }
 

--- a/SwiftTweaks/TweakColorCell.swift
+++ b/SwiftTweaks/TweakColorCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal protocol TweakColorCellDelegate: class {
+internal protocol TweakColorCellDelegate: AnyObject {
 	func tweakColorCellDidChangeValue(_ cell: TweakColorCell)
 }
 

--- a/SwiftTweaks/TweakColorEditViewController.swift
+++ b/SwiftTweaks/TweakColorEditViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal protocol TweakColorEditViewControllerDelegate: class {
+internal protocol TweakColorEditViewControllerDelegate: AnyObject {
 	func tweakColorEditViewControllerDidPressDismissButton(_ tweakColorEditViewController: TweakColorEditViewController)
 }
 

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Foundation
 
-internal protocol TweakTableCellDelegate: class {
+internal protocol TweakTableCellDelegate: AnyObject {
 	func tweakCellDidChangeCurrentValue(_ tweakCell: TweakTableCell)
 }
 

--- a/SwiftTweaks/TweaksCollectionsListViewController.swift
+++ b/SwiftTweaks/TweaksCollectionsListViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal protocol TweaksCollectionsListViewControllerDelegate: class {
+internal protocol TweaksCollectionsListViewControllerDelegate: AnyObject {
 	func tweaksCollectionsListViewControllerDidTapDismissButton(_ tweaksCollectionsListViewController: TweaksCollectionsListViewController)
 	func tweaksCollectionsListViewControllerDidTapShareButton(_ tweaksCollectionsListViewController: TweaksCollectionsListViewController, shareButton: UIBarButtonItem)
 	func tweakCollectionListViewController(_ tweakCollectionViewController: TweaksCollectionsListViewController, didTapFloatingTweakGroupButtonForTweakGroup tweakGroup: TweakGroup)

--- a/SwiftTweaks/TweaksViewController.swift
+++ b/SwiftTweaks/TweaksViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol TweaksViewControllerDelegate: class {
+public protocol TweaksViewControllerDelegate: AnyObject {
 	func tweaksViewControllerRequestsDismiss(_ tweaksViewController: TweaksViewController, completion: (() -> ())?)
 }
 


### PR DESCRIPTION
This project is warning as Swift Compiler Warning.
https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md#class-and-anyobject

```
Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
Replace 'class' with 'AnyObject'
```

## Environment

- Xcode 13.0 (13A233)