### PR TITLE
Switch from titled "Dismiss" button do system done

### DIFF
--- a/SwiftTweaks/StringOptionViewController.swift
+++ b/SwiftTweaks/StringOptionViewController.swift
@@ -51,7 +51,7 @@ internal class StringOptionViewController: UITableViewController {
 		title = tweak.tweakName
 		toolbarItems = [
 			UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-			UIBarButtonItem(title: TweaksViewController.dismissButtonTitle, style: .done, target: self, action: #selector(self.dismissButtonTapped))
+			UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(self.dismissButtonTapped))
 		]
 		
 		self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reset", style: .plain, target: self, action: #selector(StringOptionViewController.restoreDefaultValue))

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -39,7 +39,7 @@ internal final class TweakCollectionViewController: UIViewController {
 
 		toolbarItems = [
 			UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-			UIBarButtonItem(title: TweaksViewController.dismissButtonTitle, style: .done, target: self, action: #selector(self.dismissButtonTapped))
+			UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(self.dismissButtonTapped))
 		]
 	}
 

--- a/SwiftTweaks/TweakColorEditViewController.swift
+++ b/SwiftTweaks/TweakColorEditViewController.swift
@@ -77,7 +77,7 @@ internal final class TweakColorEditViewController: UIViewController {
 		title = tweak.tweakName
 		toolbarItems = [
 			UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-			UIBarButtonItem(title: TweaksViewController.dismissButtonTitle, style: .done, target: self, action: #selector(self.dismissButtonTapped))
+			UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(self.dismissButtonTapped))
 		]
 
 		view.tintColor = AppTheme.Colors.controlGrayscale

--- a/SwiftTweaks/TweaksCollectionsListViewController.swift
+++ b/SwiftTweaks/TweaksCollectionsListViewController.swift
@@ -61,7 +61,7 @@ internal final class TweaksCollectionsListViewController: UIViewController {
 
 		toolbarItems = [
 			UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-			UIBarButtonItem(title: "Dismiss", style: .done, target: self, action: #selector(self.dismissButtonTapped))
+			UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(self.dismissButtonTapped))
 		]
 	}
 

--- a/SwiftTweaks/TweaksViewController.swift
+++ b/SwiftTweaks/TweaksViewController.swift
@@ -23,8 +23,6 @@ public final class TweaksViewController: UIViewController {
 	public unowned var delegate: TweaksViewControllerDelegate
 	internal var floatingTweaksWindowPresenter: FloatingTweaksWindowPresenter?
 
-	internal static let dismissButtonTitle = NSLocalizedString("Dismiss", comment: "Button to dismiss TweaksViewController.")
-
 	public init(tweakStore: TweakStore, delegate: TweaksViewControllerDelegate) {
 		self.tweakStore = tweakStore
 		self.delegate = delegate


### PR DESCRIPTION
Hi,

I would like to propose change in labelling of end of tweak edition button. Current `Dismiss` is misleading to some people since it point to hiding Tweaks so I would like to propose `Done` - it's same how it was in FB Tweaks. Also I am switching here to system button so it should be nicely translated to all languages. 

![Simulator Screen Shot - iPhone 13 - 2022-02-14 at 12 50 14](https://user-images.githubusercontent.com/1215063/153859440-3d477fad-8f53-4d80-982b-fffcebd5b016.png)
